### PR TITLE
Enable infinite auto-play for carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -565,6 +565,15 @@
       updateCoverflow();
     });
 
+    // Avance automático e infinito del carrusel
+    setInterval(() => {
+      // Evitar avanzar si la imagen está en modo lightbox
+      if (!lightbox.classList.contains('active')) {
+        currentIndex = (currentIndex + 1) % slides.length;
+        updateCoverflow();
+      }
+    }, 3000); // cambia de imagen cada 3 segundos
+
     slides.forEach(img => {
       img.addEventListener('click', () => {
         lbImg.src = img.src;


### PR DESCRIPTION
## Summary
- add a timer that automatically advances the coverflow carousel every few seconds

## Testing
- `npm test` *(fails: `package.json` not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686ffc905db883258071c1dcfb159581