### PR TITLE
Alinear itinerario y añadir sección 'Lluvia de sobres'

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,14 +131,13 @@
 
     .itinerary {
       display:flex;
-      justify-content:space-around;
-      flex-wrap:wrap;
+      flex-direction:column;
+      align-items:center;
       gap:30px;
       margin-top:2rem;
     }
     .itinerary-item {
       text-align:center;
-      flex:1;
     }
     .itinerary-icon {
       font-size:4rem;
@@ -482,6 +481,11 @@
       Te recomendamos un outfit cómodo y elegante.<br/><br/>
       Lleva contigo algo ligero por si refresca por la tarde.<br/><br/>
       ¡Lo más importante es que disfrutes al máximo!</p>
+    </section>
+
+    <section>
+      <h2>Lluvia de sobres</h2>
+      <p>Si desean tener un detalle con nosotros, les sugerimos un sobre con dinero en efectivo. Lo más importante para nosotros es contar con su presencia en este día tan especial; su compañía es el mejor regalo.</p>
     </section>
 
     <section>


### PR DESCRIPTION
## Summary
- Mostrar el itinerario en una sola columna para mejor legibilidad
- Añadir la sección "Lluvia de sobres" para sugerir obsequiar efectivo con tono cordial

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7436fbf5883258b240edfc8996bdf