### PR TITLE
Use non-religious icon for ceremony

### DIFF
--- a/index.html
+++ b/index.html
@@ -449,7 +449,7 @@
           <p>1:00 p.m. – Recepción</p>
         </div>
         <div class="itinerary-item">
-          <i class="fa-solid fa-church itinerary-icon"></i>
+          <i class="fa-solid fa-ring itinerary-icon"></i>
           <p>2:00 p.m. – Ceremonia</p>
         </div>
         <div class="itinerary-item">


### PR DESCRIPTION
## Summary
- replace religious ceremony icon with a ring icon in itinerary

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68c74fd8e5c483259be385493b5bc433