### PR TITLE
Amplía hero a pantalla completa y ajusta botones

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,19 +105,19 @@
 </head>
 <body class="bg-ivory/95 antialiased text-base">
   <div class="min-h-screen">
-    <header class="relative isolate overflow-hidden">
+    <header class="relative isolate flex min-h-screen items-center justify-center overflow-hidden">
       <svg class="hero-divider absolute top-0 left-0" viewBox="0 0 160 40" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
         <path d="M5 35 Q40 5 80 20 T155 30" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
       </svg>
-      <div class="max-w-4xl mx-auto px-5 sm:px-6 lg:px-8 pt-20 pb-16 sm:pb-24 text-center">
+      <div class="w-full max-w-4xl mx-auto px-5 sm:px-6 lg:px-8 py-24 sm:py-32 text-center">
         <p class="uppercase tracking-[0.35em] text-sm sm:text-base text-forest/70">Nos casamos</p>
         <h1 class="mt-6 text-[2.9rem] sm:text-[4.2rem] leading-none tracking-tight drop-shadow-sm">
           Carmen &amp; Alfredo
         </h1>
         <p class="mt-6 font-serif text-xl sm:text-2xl text-forest/80">8 de noviembre de 2025 · Villa La Perla, Calvillo, Aguascalientes</p>
         <div class="mt-10 flex flex-wrap items-center justify-center gap-4">
-          <a href="boda_carmen_alfredo.ics" class="inline-flex items-center gap-2 rounded-full bg-forest px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-white shadow-lg shadow-forest/20 transition hover:bg-forest/90 hover:shadow-xl hover:shadow-forest/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gold" download="Boda_Carmen_Alfredo.ics">Guardar la fecha</a>
-          <a href="#ubicacion" class="inline-flex items-center gap-2 rounded-full border border-gold/70 px-6 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-forest transition hover:bg-champagne/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gold"><i class="fa-solid fa-location-dot text-gold"></i>¿Cómo llegar?</a>
+          <a href="boda_carmen_alfredo.ics" class="inline-flex items-center gap-2 rounded-full bg-forest px-8 py-3.5 text-base font-semibold uppercase tracking-[0.14em] text-white shadow-lg shadow-forest/20 transition hover:bg-forest/90 hover:shadow-xl hover:shadow-forest/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gold" download="Boda_Carmen_Alfredo.ics">Guardar la fecha</a>
+          <a href="#ubicacion" class="inline-flex items-center gap-2 rounded-full border border-gold/70 bg-white/80 px-8 py-3.5 text-base font-semibold uppercase tracking-[0.14em] text-forest shadow-md shadow-forest/10 transition hover:bg-champagne/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gold"><i class="fa-solid fa-location-dot text-gold"></i>¿Cómo llegar?</a>
           <button data-audio-toggle aria-pressed="false" aria-label="Reproducir nuestra canción" class="inline-flex h-12 w-12 items-center justify-center rounded-full border border-gold/80 bg-white/70 text-gold transition hover:bg-champagne/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gold">
             <i class="fa-solid fa-play"></i>
           </button>


### PR DESCRIPTION
## Summary
- extiende la cabecera principal para que abarque toda la altura de la pantalla y se centre el contenido
- amplía y realza los estilos de los botones de la hero para mejorar su legibilidad

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c84137d2e48325b3da83e5f11ef76b