### PR TITLE
Improve audio progress visibility and itinerary icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,7 +189,7 @@
             </div>
             <div class="mt-6">
               <label for="audio-progress" class="block text-xs uppercase tracking-[0.35em] text-forest/60 text-center">Progreso</label>
-              <input id="audio-progress" type="range" min="0" max="100" value="0" class="mt-2 h-2 w-full cursor-pointer appearance-none rounded-full bg-white/70 accent-gold" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Progreso de la canción" />
+              <input id="audio-progress" type="range" min="0" max="100" value="0" class="mt-2 w-full cursor-pointer" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Progreso de la canción" />
             </div>
             <audio id="wedding-audio" preload="metadata" class="hidden">
               <source src="romantic-music.mp3" type="audio/mpeg" />
@@ -229,18 +229,33 @@
           <h2 class="text-2xl sm:text-3xl font-semibold text-center">Itinerario</h2>
           <div class="mt-8 grid grid-cols-1 gap-6">
             <article class="rounded-2xl bg-white/85 p-6 text-center shadow-lg shadow-forest/5 transition duration-300 hover:-translate-y-1 hover:shadow-xl">
-              <div class="inline-flex items-center justify-center gap-2 rounded-full bg-sage/25 px-3 py-1 text-sm font-semibold text-forest"><i class="fa-solid fa-people-roof"></i> 13:00 h</div>
-              <h3 class="mt-4 font-serif text-xl text-forest">Recepción</h3>
+              <div class="flex flex-col items-center gap-4">
+                <div class="flex h-16 w-16 items-center justify-center rounded-full bg-gold/15 text-gold text-3xl shadow-lg ring-2 ring-gold/40">
+                  <i class="fa-solid fa-people-roof" aria-hidden="true"></i>
+                </div>
+                <div class="inline-flex items-center justify-center rounded-full bg-sage/25 px-4 py-2 text-sm font-semibold text-forest">13:00 h</div>
+              </div>
+              <h3 class="mt-6 font-serif text-xl text-forest">Recepción</h3>
               <p class="mt-2 text-forest/75">Nos encontraremos para darnos la bienvenida con sonrisas, abrazos y la mejor energía.</p>
             </article>
             <article class="rounded-2xl bg-champagne/35 p-6 text-center shadow-lg shadow-forest/5 transition duration-300 hover:-translate-y-1 hover:shadow-xl">
-              <div class="inline-flex items-center justify-center gap-2 rounded-full bg-sage/25 px-3 py-1 text-sm font-semibold text-forest"><i class="fa-solid fa-ring"></i> 14:00 h</div>
-              <h3 class="mt-4 font-serif text-xl text-forest">Ceremonia civil</h3>
+              <div class="flex flex-col items-center gap-4">
+                <div class="flex h-16 w-16 items-center justify-center rounded-full bg-gold/15 text-gold text-3xl shadow-lg ring-2 ring-gold/40">
+                  <i class="fa-solid fa-ring" aria-hidden="true"></i>
+                </div>
+                <div class="inline-flex items-center justify-center rounded-full bg-sage/25 px-4 py-2 text-sm font-semibold text-forest">14:00 h</div>
+              </div>
+              <h3 class="mt-6 font-serif text-xl text-forest">Ceremonia civil</h3>
               <p class="mt-2 text-forest/75">Testigos de nuestras palabras de amor y del compromiso de caminar juntos toda la vida.</p>
             </article>
             <article class="rounded-2xl bg-white/85 p-6 text-center shadow-lg shadow-forest/5 transition duration-300 hover:-translate-y-1 hover:shadow-xl">
-              <div class="inline-flex items-center justify-center gap-2 rounded-full bg-sage/25 px-3 py-1 text-sm font-semibold text-forest"><i class="fa-solid fa-champagne-glasses"></i> 15:30 h</div>
-              <h3 class="mt-4 font-serif text-xl text-forest">Celebración</h3>
+              <div class="flex flex-col items-center gap-4">
+                <div class="flex h-16 w-16 items-center justify-center rounded-full bg-gold/15 text-gold text-3xl shadow-lg ring-2 ring-gold/40">
+                  <i class="fa-solid fa-champagne-glasses" aria-hidden="true"></i>
+                </div>
+                <div class="inline-flex items-center justify-center rounded-full bg-sage/25 px-4 py-2 text-sm font-semibold text-forest">15:30 h</div>
+              </div>
+              <h3 class="mt-6 font-serif text-xl text-forest">Celebración</h3>
               <p class="mt-2 text-forest/75">Brindaremos, bailaremos y seguiremos sumando memorias inolvidables con cada uno de ustedes.</p>
             </article>
           </div>
@@ -493,6 +508,13 @@
       const toggleButtons = document.querySelectorAll('[data-audio-toggle]');
       const progress = document.getElementById('audio-progress');
       const interactionEvents = ['click', 'keydown', 'touchstart'];
+      const setProgressVisual = value => {
+        if (!progress) return;
+        const percent = Math.max(0, Math.min(100, Number(value)));
+        progress.style.setProperty('--progress-percent', `${percent}%`);
+      };
+
+      setProgressVisual(0);
 
       const attachFirstInteractionListeners = () => {
         if (!audio) return;
@@ -536,6 +558,7 @@
         updateButtonState(false);
         progress.value = '0';
         progress.setAttribute('aria-valuenow', '0');
+        setProgressVisual(0);
       });
 
       audio.addEventListener('timeupdate', () => {
@@ -543,12 +566,14 @@
         const displayValue = value.toFixed(0);
         progress.value = displayValue;
         progress.setAttribute('aria-valuenow', displayValue);
+        setProgressVisual(value);
       });
 
       progress.addEventListener('input', event => {
         if (!audio.duration) return;
         const value = Number(event.target.value);
         audio.currentTime = (value / 100) * audio.duration;
+        setProgressVisual(value);
       });
 
       // Mobile sticky actions

--- a/styles.css
+++ b/styles.css
@@ -14,6 +14,110 @@ body {
   background-repeat: no-repeat, repeat;
 }
 
+#audio-progress {
+  --progress-percent: 0%;
+  --progress-color: rgba(194, 166, 117, 0.9);
+  --track-color: rgba(47, 79, 79, 0.18);
+  --thumb-color: var(--gold);
+  appearance: none;
+  width: 100%;
+  height: 0.65rem;
+  border-radius: 999px;
+  background: linear-gradient(
+    to right,
+    var(--progress-color) 0%,
+    var(--progress-color) var(--progress-percent),
+    var(--track-color) var(--progress-percent),
+    var(--track-color) 100%
+  );
+  transition: background 0.15s linear;
+}
+
+#audio-progress:focus-visible {
+  outline: 3px solid rgba(194, 166, 117, 0.4);
+  outline-offset: 4px;
+}
+
+#audio-progress::-webkit-slider-runnable-track {
+  height: 0.65rem;
+  border-radius: 999px;
+  background: transparent;
+}
+
+#audio-progress::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--thumb-color);
+  border: 2px solid #ffffff;
+  box-shadow: 0 3px 8px rgba(47, 79, 79, 0.3);
+  margin-top: -4px;
+  transition: transform 0.2s ease;
+}
+
+#audio-progress::-webkit-slider-thumb:active {
+  transform: scale(1.05);
+}
+
+#audio-progress::-moz-range-track {
+  height: 0.65rem;
+  border-radius: 999px;
+  background: var(--track-color);
+}
+
+#audio-progress::-moz-range-progress {
+  height: 0.65rem;
+  border-radius: 999px;
+  background: var(--progress-color);
+}
+
+#audio-progress::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--thumb-color);
+  border: 2px solid #ffffff;
+  box-shadow: 0 3px 8px rgba(47, 79, 79, 0.3);
+  transition: transform 0.2s ease;
+}
+
+#audio-progress::-moz-range-thumb:active {
+  transform: scale(1.05);
+}
+
+#audio-progress::-ms-track {
+  height: 0.65rem;
+  border-radius: 999px;
+  background: transparent;
+  border-color: transparent;
+  color: transparent;
+}
+
+#audio-progress::-ms-fill-lower {
+  background: var(--progress-color);
+  border-radius: 999px;
+}
+
+#audio-progress::-ms-fill-upper {
+  background: var(--track-color);
+  border-radius: 999px;
+}
+
+#audio-progress::-ms-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--thumb-color);
+  border: 2px solid #ffffff;
+  box-shadow: 0 3px 8px rgba(47, 79, 79, 0.3);
+  transition: transform 0.2s ease;
+}
+
+#audio-progress::-ms-thumb:active {
+  transform: scale(1.05);
+}
+
 
 .hero-divider {
   width: 100%;


### PR DESCRIPTION
## Summary
- restyle the "Nuestra canción" progress slider with a custom track, thumb, and dynamic fill color so it stands out across browsers
- add prominent decorative icons above each itinerary time slot and tune spacing for a more visual schedule

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c85c4f0ce8832599baae1c9143480a