### PR TITLE
Corrige la carga de iconos en la sección de itinerario

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Playfair+Display:wght@400;500;600;700&family=Lato:wght@300;400;500;700&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-u8C1nmx7YwjlzAIXazhbugzuDUFcPRl1BDpRP70dNDO7xjMnIKh4j/wcgUp3NEPoPFcAckS4iigFsMNBX/0P+A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script src="https://cdn.tailwindcss.com?plugins=typography" defer></script>
   <script>
     tailwind = window.tailwind || {};


### PR DESCRIPTION
## Resumen
- actualiza la cadena de integridad (SRI) del enlace CDN de Font Awesome para que coincida con la versión 6.5.2
- asegura que las clases `fa-solid` puedan renderizar los iconos del itinerario y otros elementos

## Pruebas
- no se requirieron pruebas

------
https://chatgpt.com/codex/tasks/task_e_68c8665e62188325bc9a81c45fcb9f20