### PR TITLE
Ajusta hero en móviles

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,8 +111,10 @@
       </svg>
       <div class="w-full max-w-4xl mx-auto px-5 sm:px-6 lg:px-8 py-24 sm:py-32 text-center">
         <p class="uppercase tracking-[0.35em] text-sm sm:text-base text-forest/70">Nos casamos</p>
-        <h1 class="mt-6 text-[3.2rem] sm:text-[4.8rem] leading-none tracking-tight drop-shadow-sm">
-          Carmen y Alfredo
+        <h1 class="mt-6 text-[3.2rem] sm:text-[4.8rem] leading-none tracking-tight drop-shadow-sm flex flex-col items-center justify-center gap-1 sm:flex-row sm:gap-2">
+          <span>Carmen</span>
+          <span>y</span>
+          <span>Alfredo</span>
         </h1>
         <p class="mt-6 font-serif text-xl sm:text-2xl text-forest/80">8 de noviembre de 2025 · Villa La Perla, Calvillo, Aguascalientes</p>
       </div>


### PR DESCRIPTION
## Summary
- descompone el encabezado principal en tres líneas para las vistas móviles
- mantiene la alineación horizontal del título en pantallas más anchas usando flexbox receptivo

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c86ad4e2d883258abea842b54a2653