### PR TITLE
Add animated floral accents to hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,22 +105,50 @@
 </head>
 <body class="bg-ivory/95 antialiased text-base">
   <div class="min-h-screen">
-    <header class="relative isolate flex min-h-screen items-center justify-center overflow-hidden">
-      <svg class="hero-divider absolute top-0 left-0" viewBox="0 0 160 40" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-        <path d="M5 35 Q40 5 80 20 T155 30" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
-      </svg>
+    <header class="relative isolate flex min-h-screen items-center justify-center overflow-hidden" data-hero>
       <div class="w-full max-w-4xl mx-auto px-5 sm:px-6 lg:px-8 py-24 sm:py-32 text-center">
         <p class="uppercase tracking-[0.35em] text-sm sm:text-base text-forest/70">Nos casamos</p>
-        <h1 class="mt-6 text-[3.2rem] sm:text-[4.8rem] leading-none tracking-tight drop-shadow-sm flex flex-col items-center justify-center gap-1 sm:flex-row sm:gap-2">
-          <span>Carmen</span>
-          <span>y</span>
-          <span>Alfredo</span>
-        </h1>
-        <p class="mt-6 font-serif text-xl sm:text-2xl text-forest/80">8 de noviembre de 2025 · Villa La Perla, Calvillo, Aguascalientes</p>
+        <div class="mt-10 flex flex-col items-center gap-6 sm:gap-8">
+          <svg class="hero-floral pointer-events-none h-12 w-64 max-w-full text-gold opacity-0 translate-y-2 transition-all duration-700 ease-out sm:h-14 sm:w-80" viewBox="0 0 360 120" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <g fill="none" stroke="currentColor" stroke-width="1.35" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.6">
+              <path d="M24 84 C68 40 132 36 180 58 C236 82 292 86 336 54" />
+              <path d="M88 58 C82 50 70 44 58 46" />
+              <path d="M88 58 C94 50 106 44 118 46" />
+              <path d="M140 76 C134 66 120 60 108 62" />
+              <path d="M140 76 C146 66 160 60 172 62" />
+              <path d="M232 74 C226 66 214 62 204 66" />
+              <path d="M232 74 C238 66 250 62 260 66" />
+              <path d="M292 54 C286 46 274 40 262 42" />
+              <path d="M292 54 C298 46 310 40 322 42" />
+              <path d="M180 58 C184 50 192 44 202 42" />
+              <path d="M180 58 C176 50 168 44 158 42" />
+            </g>
+          </svg>
+          <div class="flex flex-col items-center gap-4 sm:gap-5">
+            <h1 class="text-[3.2rem] sm:text-[4.8rem] leading-none tracking-tight drop-shadow-sm flex flex-col items-center justify-center gap-1 sm:flex-row sm:gap-2">
+              <span>Carmen</span>
+              <span>y</span>
+              <span>Alfredo</span>
+            </h1>
+            <p class="font-serif text-xl sm:text-2xl text-forest/80">8 de noviembre de 2025 · Villa La Perla, Calvillo, Aguascalientes</p>
+          </div>
+          <svg class="hero-floral pointer-events-none h-12 w-64 max-w-full text-gold opacity-0 translate-y-2 transition-all duration-700 ease-out sm:h-14 sm:w-80 rotate-180" viewBox="0 0 360 120" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <g fill="none" stroke="currentColor" stroke-width="1.35" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.6">
+              <path d="M24 84 C68 40 132 36 180 58 C236 82 292 86 336 54" />
+              <path d="M88 58 C82 50 70 44 58 46" />
+              <path d="M88 58 C94 50 106 44 118 46" />
+              <path d="M140 76 C134 66 120 60 108 62" />
+              <path d="M140 76 C146 66 160 60 172 62" />
+              <path d="M232 74 C226 66 214 62 204 66" />
+              <path d="M232 74 C238 66 250 62 260 66" />
+              <path d="M292 54 C286 46 274 40 262 42" />
+              <path d="M292 54 C298 46 310 40 322 42" />
+              <path d="M180 58 C184 50 192 44 202 42" />
+              <path d="M180 58 C176 50 168 44 158 42" />
+            </g>
+          </svg>
+        </div>
       </div>
-      <svg class="hero-divider absolute bottom-0 right-0 rotate-180" viewBox="0 0 160 40" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-        <path d="M5 35 Q40 5 80 20 T155 30" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
-      </svg>
     </header>
 
     <main class="max-w-4xl mx-auto px-5 sm:px-6 lg:px-8 space-y-16 py-12 sm:py-16">
@@ -366,6 +394,16 @@
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+      const hero = document.querySelector('[data-hero]');
+      if (hero) {
+        const activateHero = () => hero.classList.add('is-active');
+        if (prefersReducedMotion) {
+          activateHero();
+        } else {
+          requestAnimationFrame(activateHero);
+        }
+      }
 
       // Countdown
       const targetDate = new Date('2025-11-08T13:00:00-06:00').getTime();

--- a/styles.css
+++ b/styles.css
@@ -119,12 +119,6 @@ body {
 }
 
 
-.hero-divider {
-  width: 100%;
-  height: 54px;
-  color: var(--gold);
-}
-
 .section-card {
   box-shadow: 0 38px 95px -28px rgba(47, 79, 79, 0.72), 0 22px 55px -32px rgba(47, 79, 79, 0.6);
   transition: box-shadow 0.3s ease;
@@ -154,6 +148,19 @@ body {
 .blur-up.loaded {
   filter: blur(0);
   transform: scale(1);
+}
+
+[data-hero].is-active .hero-floral {
+  opacity: 1;
+  --tw-translate-y: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-hero] .hero-floral {
+    opacity: 1;
+    --tw-translate-y: 0;
+    transition-duration: 0ms;
+  }
 }
 
 #lightbox {


### PR DESCRIPTION
## Summary
- add gold floral svg flourishes around the hero names with a gentle entrance animation
- remove the previous divider graphics and hook the animation into reduced-motion preferences

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c86c793bcc8325a572d635b9c683a6