### PR TITLE
Replace hero desktop adornments with PNG images

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,21 +109,12 @@
       <div class="w-full max-w-4xl mx-auto px-5 sm:px-6 lg:px-8 py-24 sm:py-32 text-center">
         <p class="uppercase tracking-[0.35em] text-sm sm:text-base text-forest/70">Nos casamos</p>
         <div class="mt-10 flex flex-col items-center gap-6 sm:gap-8">
-          <svg class="hero-floral pointer-events-none h-12 w-64 max-w-full text-gold opacity-0 translate-y-2 transition-all duration-700 ease-out sm:h-14 sm:w-80" viewBox="0 0 360 120" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-            <g fill="none" stroke="currentColor" stroke-width="1.35" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.6">
-              <path d="M24 84 C68 40 132 36 180 58 C236 82 292 86 336 54" />
-              <path d="M88 58 C82 50 70 44 58 46" />
-              <path d="M88 58 C94 50 106 44 118 46" />
-              <path d="M140 76 C134 66 120 60 108 62" />
-              <path d="M140 76 C146 66 160 60 172 62" />
-              <path d="M232 74 C226 66 214 62 204 66" />
-              <path d="M232 74 C238 66 250 62 260 66" />
-              <path d="M292 54 C286 46 274 40 262 42" />
-              <path d="M292 54 C298 46 310 40 322 42" />
-              <path d="M180 58 C184 50 192 44 202 42" />
-              <path d="M180 58 C176 50 168 44 158 42" />
-            </g>
-          </svg>
+          <img
+            src="adorno_arriba.png"
+            alt=""
+            class="hero-floral pointer-events-none h-12 w-64 max-w-full text-gold opacity-0 translate-y-2 transition-all duration-700 ease-out sm:h-14 sm:w-80"
+            aria-hidden="true"
+          />
           <div class="flex flex-col items-center gap-4 sm:gap-5">
             <div class="hero-mobile-adornment">
               <h1 class="text-[3.2rem] sm:text-[4.8rem] leading-none tracking-tight drop-shadow-sm flex flex-col items-center justify-center gap-1 sm:flex-row sm:gap-2">
@@ -140,21 +131,12 @@
             </div>
             <p class="font-serif text-xl sm:text-2xl text-forest/80 text-center hidden sm:block">8 de noviembre de 2025 · Villa La Perla, Calvillo, Aguascalientes</p>
           </div>
-          <svg class="hero-floral pointer-events-none h-12 w-64 max-w-full text-gold opacity-0 translate-y-2 transition-all duration-700 ease-out sm:h-14 sm:w-80 rotate-180" viewBox="0 0 360 120" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-            <g fill="none" stroke="currentColor" stroke-width="1.35" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.6">
-              <path d="M24 84 C68 40 132 36 180 58 C236 82 292 86 336 54" />
-              <path d="M88 58 C82 50 70 44 58 46" />
-              <path d="M88 58 C94 50 106 44 118 46" />
-              <path d="M140 76 C134 66 120 60 108 62" />
-              <path d="M140 76 C146 66 160 60 172 62" />
-              <path d="M232 74 C226 66 214 62 204 66" />
-              <path d="M232 74 C238 66 250 62 260 66" />
-              <path d="M292 54 C286 46 274 40 262 42" />
-              <path d="M292 54 C298 46 310 40 322 42" />
-              <path d="M180 58 C184 50 192 44 202 42" />
-              <path d="M180 58 C176 50 168 44 158 42" />
-            </g>
-          </svg>
+          <img
+            src="adorno_abajo.png"
+            alt=""
+            class="hero-floral pointer-events-none h-12 w-64 max-w-full text-gold opacity-0 translate-y-2 transition-all duration-700 ease-out sm:h-14 sm:w-80 rotate-180"
+            aria-hidden="true"
+          />
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- swap the hero section's SVG flourishes for the new PNG assets on desktop view

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c87ceb6a8483258ad150be56e4cf89