### PR TITLE
Ocultar adornos en móvil y corregir adorno inferior

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
           <img
             src="adorno_arriba.png"
             alt=""
-            class="hero-floral pointer-events-none h-12 w-64 max-w-full text-gold opacity-0 translate-y-2 transition-all duration-700 ease-out sm:h-14 sm:w-80"
+            class="hero-floral pointer-events-none hidden h-12 w-64 max-w-full text-gold opacity-0 translate-y-2 transition-all duration-700 ease-out sm:block sm:h-14 sm:w-80"
             aria-hidden="true"
             data-hero-floral
           />
@@ -143,7 +143,7 @@
           <img
             src="adorno_abajo.png"
             alt=""
-            class="hero-floral pointer-events-none h-12 w-64 max-w-full text-gold opacity-0 translate-y-2 transition-all duration-700 ease-out sm:h-14 sm:w-80 rotate-180"
+            class="hero-floral pointer-events-none hidden h-12 w-64 max-w-full text-gold opacity-0 translate-y-2 transition-all duration-700 ease-out sm:block sm:h-14 sm:w-80"
             aria-hidden="true"
             data-hero-floral
           />


### PR DESCRIPTION
## Summary
- oculta los adornos superior e inferior del héroe en vistas móviles para evitar que se muestren en iPhone
- ajusta el adorno inferior del héroe para que use el archivo adorno_abajo.png sin rotación y se vea distinto del superior en escritorio

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8820b5e008325bee60a898598cc3f