### PR TITLE
Ensure hero names use Great Vibes font

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
           <div class="flex flex-col items-center gap-4 sm:gap-5">
             <div class="hero-mobile-adornment">
               <h1
-                class="text-[3.2rem] sm:text-[4.8rem] leading-none tracking-tight drop-shadow-sm flex flex-col items-center justify-center gap-1 sm:flex-row sm:gap-2 w-fit mx-auto"
+                class="font-display text-[3.2rem] sm:text-[4.8rem] leading-none tracking-tight drop-shadow-sm flex flex-col items-center justify-center gap-1 sm:flex-row sm:gap-2 w-fit mx-auto"
                 data-hero-names
               >
                 <span>Carmen</span>

--- a/styles.css
+++ b/styles.css
@@ -168,6 +168,14 @@ body {
   gap: 0.75rem;
 }
 
+[data-hero-names] {
+  font-family: 'Great Vibes', cursive;
+}
+
+[data-hero-names] span {
+  font-family: inherit;
+}
+
 @media (max-width: 639px) {
   .hero-mobile-adornment h1 {
     font-size: clamp(2.6rem, 8vw + 1rem, 3.1rem);


### PR DESCRIPTION
## Summary
- apply the `font-display` utility to the hero heading so the couple's names always render with Great Vibes
- enforce the Great Vibes family on the hero name container and spans for consistent typography across viewports

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c884694d748325899fb2cee6a22416