### PR TITLE
Remove colored borders from itinerary icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,7 +260,7 @@
           <div class="mt-8 grid grid-cols-1 gap-6">
             <article class="rounded-2xl bg-white/85 p-6 text-center shadow-lg shadow-forest/5 transition duration-300 hover:-translate-y-1 hover:shadow-xl">
               <div class="flex flex-col items-center gap-4">
-                <div class="flex h-16 w-16 items-center justify-center rounded-full bg-gold/15 text-gold text-3xl shadow-lg ring-2 ring-gold/40">
+                <div class="flex h-16 w-16 items-center justify-center rounded-full bg-gold/15 text-gold text-3xl shadow-lg shadow-gold/30">
                   <i class="fa-solid fa-people-roof" aria-hidden="true"></i>
                 </div>
                 <div class="inline-flex items-center justify-center rounded-full bg-sage/25 px-4 py-2 text-sm font-semibold text-forest">13:00 h</div>
@@ -270,7 +270,7 @@
             </article>
             <article class="rounded-2xl bg-champagne/35 p-6 text-center shadow-lg shadow-forest/5 transition duration-300 hover:-translate-y-1 hover:shadow-xl">
               <div class="flex flex-col items-center gap-4">
-                <div class="flex h-16 w-16 items-center justify-center rounded-full bg-gold/15 text-gold text-3xl shadow-lg ring-2 ring-gold/40">
+                <div class="flex h-16 w-16 items-center justify-center rounded-full bg-gold/15 text-gold text-3xl shadow-lg shadow-gold/30">
                   <i class="fa-solid fa-ring" aria-hidden="true"></i>
                 </div>
                 <div class="inline-flex items-center justify-center rounded-full bg-sage/25 px-4 py-2 text-sm font-semibold text-forest">14:00 h</div>
@@ -280,7 +280,7 @@
             </article>
             <article class="rounded-2xl bg-white/85 p-6 text-center shadow-lg shadow-forest/5 transition duration-300 hover:-translate-y-1 hover:shadow-xl">
               <div class="flex flex-col items-center gap-4">
-                <div class="flex h-16 w-16 items-center justify-center rounded-full bg-gold/15 text-gold text-3xl shadow-lg ring-2 ring-gold/40">
+                <div class="flex h-16 w-16 items-center justify-center rounded-full bg-gold/15 text-gold text-3xl shadow-lg shadow-gold/30">
                   <i class="fa-solid fa-champagne-glasses" aria-hidden="true"></i>
                 </div>
                 <div class="inline-flex items-center justify-center rounded-full bg-sage/25 px-4 py-2 text-sm font-semibold text-forest">15:30 h</div>


### PR DESCRIPTION
## Summary
- remove the gold ring border from itinerary icons so the circles keep only their soft shadowing

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c8b13733788325b4d5c39f62d0b9ab