### PR TITLE
Adjust hero name letter spacing for continuity

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -176,6 +176,18 @@ body {
   font-family: inherit;
 }
 
+[data-hero-names] span:first-child,
+[data-hero-names] span:last-child {
+  letter-spacing: -0.055em;
+}
+
+@media (min-width: 640px) {
+  [data-hero-names] span:first-child,
+  [data-hero-names] span:last-child {
+    letter-spacing: -0.065em;
+  }
+}
+
 @media (max-width: 639px) {
   .hero-mobile-adornment h1 {
     font-size: clamp(2.6rem, 8vw + 1rem, 3.1rem);


### PR DESCRIPTION
## Summary
- add targeted negative letter spacing to the hero names to emulate continuous script lettering
- increase the effect on larger screens for better flow of the cursive font

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cad831f2f08325b1645834fe524ff5