### PR TITLE
Fix spacing in hero names on desktop

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -174,6 +174,7 @@ body {
 
 [data-hero-names] span {
   font-family: inherit;
+  letter-spacing: normal;
 }
 
 [data-hero-names] span:first-child,


### PR DESCRIPTION
## Summary
- restore normal letter spacing on each hero name span so the desktop view keeps the spaces between the words

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68caf9cfd0b8832594af78702ddf6be7