### PR TITLE
Add checklist for sent invitations in admin table

### DIFF
--- a/admin-invitados.html
+++ b/admin-invitados.html
@@ -420,6 +420,25 @@
       margin-top: 0.35rem;
     }
 
+    .sent-status-cell {
+      text-align: center;
+      vertical-align: middle;
+    }
+
+    .sent-checkbox {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-size: 0.9rem;
+      color: #1f2937;
+    }
+
+    .sent-checkbox input[type="checkbox"] {
+      width: 1rem;
+      height: 1rem;
+      accent-color: #1d4ed8;
+    }
+
     .table-wrapper {
       overflow-x: auto;
     }
@@ -495,12 +514,13 @@ Confirma tu asistencia aquí: {url}</textarea>
             <th scope="col">Slug</th>
             <th scope="col">Lugares</th>
             <th scope="col">WhatsApp</th>
+            <th scope="col">Invitación enviada</th>
             <th scope="col">Acciones</th>
           </tr>
         </thead>
         <tbody id="guest-table-body">
           <tr>
-            <td class="table-empty" colspan="5">Sin datos. Carga el JSON.</td>
+            <td class="table-empty" colspan="6">Sin datos. Carga el JSON.</td>
           </tr>
         </tbody>
       </table>
@@ -552,7 +572,8 @@ Confirma tu asistencia aquí: {url}</textarea>
       template: document.getElementById('template-input').value,
       searchTerm: '',
       filter: 'all',
-      selectedSlug: ''
+      selectedSlug: '',
+      sentStatus: Object.create(null)
     };
 
     const statusText = document.getElementById('status-text');
@@ -648,6 +669,13 @@ Confirma tu asistencia aquí: {url}</textarea>
 
     function applyGuests(data) {
       state.guests = data.map(sanitizeGuest).filter(Boolean);
+      const nextStatus = Object.create(null);
+      state.guests.forEach((guest) => {
+        nextStatus[guest.slug] = Object.prototype.hasOwnProperty.call(state.sentStatus, guest.slug)
+          ? state.sentStatus[guest.slug]
+          : false;
+      });
+      state.sentStatus = nextStatus;
       state.selectedSlug = state.guests.length ? state.guests[0].slug : '';
       renderTable();
     }
@@ -863,7 +891,7 @@ Confirma tu asistencia aquí: {url}</textarea>
 
       if (!state.guests.length) {
         const row = document.createElement('tr');
-        row.innerHTML = '<td class="table-empty" colspan="5">Sin datos. Carga el JSON.</td>';
+        row.innerHTML = '<td class="table-empty" colspan="6">Sin datos. Carga el JSON.</td>';
         tableBody.appendChild(row);
         state.selectedSlug = '';
         updateCounters();
@@ -873,7 +901,7 @@ Confirma tu asistencia aquí: {url}</textarea>
 
       if (!guests.length) {
         const row = document.createElement('tr');
-        row.innerHTML = '<td class="table-empty" colspan="5">Sin coincidencias.</td>';
+        row.innerHTML = '<td class="table-empty" colspan="6">Sin coincidencias.</td>';
         tableBody.appendChild(row);
         updateCounters();
         updatePreview();
@@ -908,6 +936,7 @@ Confirma tu asistencia aquí: {url}</textarea>
         const whatsappCell = guest.normalizedWhatsapp
           ? `<div>${escapeHtml(guest.normalizedWhatsapp.display)}</div><span class="badge ok">ok</span>`
           : '<span class="badge warning">Sin número</span>';
+        const sentChecked = Boolean(state.sentStatus[guest.slug]);
 
         row.innerHTML = `
           <td>
@@ -918,6 +947,12 @@ Confirma tu asistencia aquí: {url}</textarea>
           <td><code>${escapeHtml(guest.slug || '')}</code></td>
           <td>${seatsContent}</td>
           <td>${whatsappCell}</td>
+          <td class="sent-status-cell">
+            <label class="sent-checkbox">
+              <input type="checkbox" data-action="sent-toggle" data-slug="${encodeURIComponent(guest.slug)}" ${sentChecked ? 'checked' : ''}>
+              Enviada
+            </label>
+          </td>
           <td class="actions">
             <button type="button" class="secondary" data-action="open" data-slug="${encodeURIComponent(guest.slug)}">Abrir</button>
             <button type="button" data-action="copy" data-slug="${encodeURIComponent(guest.slug)}">Copiar enlace</button>
@@ -1042,6 +1077,9 @@ Confirma tu asistencia aquí: {url}</textarea>
     });
 
     tableBody.addEventListener('click', async (event) => {
+      if (event.target.closest('.sent-checkbox')) {
+        return;
+      }
       const row = event.target.closest('tr[data-slug]');
       const button = event.target.closest('button[data-action]');
       if (row && !button) {
@@ -1113,6 +1151,18 @@ Confirma tu asistencia aquí: {url}</textarea>
         default:
           break;
       }
+    });
+
+    tableBody.addEventListener('change', (event) => {
+      const checkbox = event.target.closest('input[data-action="sent-toggle"]');
+      if (!checkbox) {
+        return;
+      }
+      const slug = decodeURIComponent(checkbox.dataset.slug || '');
+      if (!slug) {
+        return;
+      }
+      state.sentStatus[slug] = checkbox.checked;
     });
 
     renderTable();


### PR DESCRIPTION
## Summary
- add an "Invitación enviada" column with a checkbox for cada invitad@
- store the estado de envío en memoria para que se mantenga al filtrar o recargar los datos
- ajustar estilos y manejadores para evitar que seleccionar la casilla cambie la fila activa

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d4379d14688325bbc30f927339d299