### PR TITLE
Make admin panel responsive with iPhone layout

### DIFF
--- a/admin-invitados.html
+++ b/admin-invitados.html
@@ -17,6 +17,7 @@
       min-height: 100vh;
       display: flex;
       flex-direction: column;
+      background: #f8f9fb;
     }
 
     header {
@@ -26,6 +27,29 @@
       position: sticky;
       top: 0;
       z-index: 10;
+    }
+
+    @supports (padding: max(0px)) {
+      body {
+        padding-bottom: max(0px, env(safe-area-inset-bottom));
+        padding-bottom: max(0px, constant(safe-area-inset-bottom));
+      }
+
+      header {
+        padding-top: calc(1.5rem + env(safe-area-inset-top));
+        padding-top: calc(1.5rem + constant(safe-area-inset-top));
+        padding-left: max(1rem, env(safe-area-inset-left));
+        padding-left: max(1rem, constant(safe-area-inset-left));
+        padding-right: max(1rem, env(safe-area-inset-right));
+        padding-right: max(1rem, constant(safe-area-inset-right));
+      }
+
+      main {
+        padding-left: max(1rem, env(safe-area-inset-left));
+        padding-left: max(1rem, constant(safe-area-inset-left));
+        padding-right: max(1rem, env(safe-area-inset-right));
+        padding-right: max(1rem, constant(safe-area-inset-right));
+      }
     }
 
     h1 {
@@ -424,13 +448,31 @@
       overflow-x: auto;
     }
 
+    @media (max-width: 820px) {
+      .layout {
+        gap: 1rem;
+      }
+
+      .preview-card {
+        order: -1;
+      }
+    }
+
     @media (max-width: 640px) {
       header {
-        padding: 1.25rem 0.75rem;
+        padding: 1.25rem 0.85rem;
       }
 
       main {
         padding: 0.75rem;
+      }
+
+      .controls-grid {
+        grid-template-columns: minmax(0, 1fr);
+      }
+
+      .actions {
+        gap: 0.4rem;
       }
 
       button {
@@ -440,6 +482,141 @@
       thead th,
       tbody td {
         padding: 0.75rem;
+      }
+    }
+
+    @media (max-width: 480px) {
+      :root {
+        font-size: 15px;
+      }
+
+      header {
+        padding-bottom: 0.75rem;
+      }
+
+      h1 {
+        font-size: 1.35rem;
+      }
+
+      .controls-grid {
+        gap: 0.75rem;
+      }
+
+      label {
+        font-size: 0.85rem;
+      }
+
+      input[type="url"],
+      input[type="text"],
+      textarea,
+      select {
+        font-size: 1rem;
+      }
+
+      .actions {
+        flex-direction: column;
+      }
+
+      button {
+        width: 100%;
+        flex: none;
+      }
+
+      .layout {
+        gap: 0.75rem;
+      }
+
+      .preview-card {
+        padding: 1rem;
+      }
+
+      .table-wrapper {
+        overflow: visible;
+      }
+
+      table,
+      thead,
+      tbody,
+      th,
+      td,
+      tr {
+        display: block;
+      }
+
+      thead {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        clip-path: inset(50%);
+        white-space: nowrap;
+      }
+
+      tbody tr {
+        border: 1px solid #e2e8f0;
+        border-radius: 0.9rem;
+        padding: 0.85rem 1rem;
+        margin-bottom: 0.85rem;
+        box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
+        background: white;
+      }
+
+      tbody tr.selected {
+        border-color: rgba(37, 99, 235, 0.35);
+        box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.18);
+      }
+
+      tbody td {
+        padding: 0.55rem 0;
+        border: none;
+        font-size: 0.95rem;
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      tbody td::before {
+        content: attr(data-label);
+        font-size: 0.75rem;
+        font-weight: 600;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: #64748b;
+      }
+
+      tbody td.actions {
+        display: grid;
+        grid-template-columns: 1fr;
+        padding-top: 0.75rem;
+        gap: 0.5rem;
+      }
+
+      tbody td.actions button {
+        width: 100%;
+      }
+
+      tbody td.table-empty {
+        display: block;
+        text-align: center;
+        padding: 1rem 0.5rem;
+        color: #475569;
+      }
+
+      tbody td.table-empty::before {
+        display: none;
+      }
+
+      tbody tr.table-message {
+        border: none;
+        box-shadow: none;
+        background: transparent;
+        padding: 0;
+        margin-bottom: 0;
+      }
+
+      tbody tr.table-message td {
+        display: block;
+        padding: 1rem 0.5rem;
       }
     }
   </style>
@@ -499,7 +676,7 @@ Confirma tu asistencia aquí: {url}</textarea>
           </tr>
         </thead>
         <tbody id="guest-table-body">
-          <tr>
+          <tr class="table-message">
             <td class="table-empty" colspan="5">Sin datos. Carga el JSON.</td>
           </tr>
         </tbody>
@@ -858,6 +1035,7 @@ Confirma tu asistencia aquí: {url}</textarea>
 
       if (!state.guests.length) {
         const row = document.createElement('tr');
+        row.classList.add('table-message');
         row.innerHTML = '<td class="table-empty" colspan="5">Sin datos. Carga el JSON.</td>';
         tableBody.appendChild(row);
         state.selectedSlug = '';
@@ -868,6 +1046,7 @@ Confirma tu asistencia aquí: {url}</textarea>
 
       if (!guests.length) {
         const row = document.createElement('tr');
+        row.classList.add('table-message');
         row.innerHTML = '<td class="table-empty" colspan="5">Sin coincidencias.</td>';
         tableBody.appendChild(row);
         updateCounters();
@@ -905,15 +1084,15 @@ Confirma tu asistencia aquí: {url}</textarea>
           : '<span class="badge warning">Sin número</span>';
 
         row.innerHTML = `
-          <td>
+          <td data-label="Nombre">
             <span class="name">${escapeHtml(guest.displayName || 'Invitad@')}</span>
             ${chipsHtml}
             ${noteHtml}
           </td>
-          <td><code>${escapeHtml(guest.slug || '')}</code></td>
-          <td>${seatsContent}</td>
-          <td>${whatsappCell}</td>
-          <td class="actions">
+          <td data-label="Slug"><code>${escapeHtml(guest.slug || '')}</code></td>
+          <td data-label="Lugares">${seatsContent}</td>
+          <td data-label="WhatsApp">${whatsappCell}</td>
+          <td class="actions" data-label="Acciones">
             <button type="button" class="secondary" data-action="open" data-slug="${encodeURIComponent(guest.slug)}">Abrir</button>
             <button type="button" data-action="copy" data-slug="${encodeURIComponent(guest.slug)}">Copiar enlace</button>
             <button type="button" data-action="whatsapp-guest" data-slug="${encodeURIComponent(guest.slug)}" ${guestWhatsappLink ? '' : 'disabled'}>Enviar WhatsApp</button>


### PR DESCRIPTION
## Summary
- adjust admin guest page layout with safe-area padding and refined spacing for small screens
- convert the guest table into card-style entries on narrow viewports with data labels for clarity
- ensure empty states and action buttons remain usable on mobile, including iPhone-specific optimizations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4b6b7f36c83259f5c7fffbcdffd83