### PR TITLE
Ajusta panel de datos e iconos en admin

### DIFF
--- a/admin-invitados.html
+++ b/admin-invitados.html
@@ -109,6 +109,16 @@
       padding: 0 1.1rem 1.1rem;
     }
 
+    .control-section > .template-control,
+    .control-section > .actions {
+      margin: 0;
+      padding: 0 1.1rem 1.1rem;
+    }
+
+    .control-section > .actions {
+      padding-top: 0.35rem;
+    }
+
     .template-control {
       margin-bottom: 1rem;
     }
@@ -715,22 +725,22 @@
           </select>
         </label>
       </div>
-    </details>
-    <div class="template-control">
-      <label for="template-input">
-        Plantilla de WhatsApp
-        <textarea id="template-input">{greeting}
+      <div class="template-control">
+        <label for="template-input">
+          Plantilla de WhatsApp
+          <textarea id="template-input">{greeting}
 
 {body}
 
 Confirma tu asistencia aquí: {url}</textarea>
-      </label>
-    </div>
-    <div class="actions primary-actions">
-      <button id="fetch-button" type="button">Cargar JSON</button>
-      <button id="file-button" type="button" class="secondary">Cargar archivo…</button>
-      <input id="file-input" type="file" accept="application/json" style="display:none">
-    </div>
+        </label>
+      </div>
+      <div class="actions primary-actions">
+        <button id="fetch-button" type="button">Cargar JSON</button>
+        <button id="file-button" type="button" class="secondary">Cargar archivo…</button>
+        <input id="file-input" type="file" accept="application/json" style="display:none">
+      </div>
+    </details>
     <div class="status-bar" id="status-text">Listo.</div>
     <div class="counters">
       <span>Total: <strong id="total-count">0</strong></span>
@@ -1197,14 +1207,13 @@ Confirma tu asistencia aquí: {url}</textarea>
             </button>
             <button type="button" data-action="copy" data-slug="${encodeURIComponent(guest.slug)}" aria-label="Copiar enlace" title="Copiar enlace">
               <svg class="button-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path d="M10.59 13.41a1 1 0 0 1 0-1.41l3.18-3.18a3 3 0 1 1 4.24 4.24l-1.41 1.41-1.41-1.41 1.41-1.41a1 1 0 1 0-1.41-1.41l-3.18 3.18a3 3 0 0 1-4.24-4.24l1.41-1.41 1.41 1.41-1.41 1.41a1 1 0 1 0 1.41 1.41z" fill="currentColor" />
-                <path d="M7 7h4V5H7a2 2 0 0 0-2 2v4h2V7zm10 10h-4v2h4a2 2 0 0 0 2-2v-4h-2v4z" fill="currentColor" />
+                <path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h3V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h3v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-3v1.9h3c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-3V17h3c2.76 0 5-2.24 5-5s-2.24-5-5-5z" fill="currentColor" />
               </svg>
               <span class="button-text">Copiar enlace</span>
             </button>
             <button type="button" data-action="whatsapp-guest" data-slug="${encodeURIComponent(guest.slug)}" ${guestWhatsappLink ? '' : 'disabled'} aria-label="Enviar por WhatsApp" title="Enviar por WhatsApp">
               <svg class="button-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path d="M12 2a9 9 0 0 0-7.81 13.5L4 22l4.72-1.24A9 9 0 1 0 12 2zm0 2a7 7 0 1 1-3.35 13.16l-.24-.14-2.79.73.75-2.72-.16-.28A7 7 0 0 1 12 4zm-3.1 4.38c.14-.3.37-.3.56-.3h.48c.16 0 .4 0 .5.38.18.62.55 1.5 1.18 2.13s1.51 1 2.13 1.18c.38.1.38.34.38.5v.48c0 .19 0 .42-.3.56-.3.14-1.9.92-4.43-1.6s-1.74-4.13-1.6-4.43z" fill="currentColor" />
+                <path d="M.057 24l1.687-6.163A11.88 11.88 0 0 1 0 11.887C.003 5.326 5.38 0 12.004 0a11.86 11.86 0 0 1 8.44 3.49 11.83 11.83 0 0 1 3.497 8.425C23.938 18.579 18.563 24 11.936 24c-1.99-.001-3.951-.5-5.688-1.448zm6.597-3.807a9.78 9.78 0 0 0 5.282 1.533c5.448 0 9.886-4.434 9.889-9.885.002-5.462-4.415-9.89-9.881-9.894-5.452 0-9.887 4.434-9.889 9.884-.001 2.225.651 3.891 1.746 5.634l-.999 3.648zm11.387-5.464c-.074-.123-.272-.198-.57-.347-.297-.149-1.758-.868-2.031-.967-.272-.099-.47-.149-.669.149-.198.297-.768.967-.941 1.165-.173.198-.347.223-.644.074-.297-.149-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.297-.347.446-.521.149-.174.198-.298.297-.497.099-.198.05-.372-.025-.521-.074-.149-.669-1.611-.916-2.207-.242-.579-.487-.5-.669-.51l-.57-.01c-.198 0-.52.074-.792.372s-1.04 1.016-1.04 2.479 1.065 2.876 1.213 3.074c.149.198 2.095 3.2 5.076 4.487.709.306 1.262.489 1.694.626.712.227 1.36.195 1.872.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413z" fill="currentColor" />
               </svg>
               <span class="button-text">Enviar WhatsApp</span>
             </button>


### PR DESCRIPTION
## Summary
- integra la plantilla de WhatsApp y los botones de carga dentro del panel colapsable de opciones de datos
- ajusta estilos del panel para mantener el espaciado coherente
- actualiza los íconos de Copiar enlace y Enviar WhatsApp para mejorar su apariencia

## Testing
- no se ejecutaron pruebas (no aplica)


------
https://chatgpt.com/codex/tasks/task_e_68d4bd2d47388325acea7f3bb8f6da6f