### PR TITLE
Add bank details flip card for lluvia de sobres section

### DIFF
--- a/index.html
+++ b/index.html
@@ -400,7 +400,55 @@
             <h2 class="mt-0 text-2xl sm:text-3xl font-semibold">Lluvia de sobres</h2>
           </div>
           <p class="mt-6 text-base sm:text-lg leading-8 text-forest/80">Su presencia es el obsequio más valioso que podemos recibir en este día tan importante. Si además desean tener un detalle, les agradeceremos que nos acompañen en la tradición de la “Lluvia de Sobres”.</p>
-          <a href="boda_carmen_alfredo.ics" class="mt-6 button button--outline button--sm button--responsive">Añadir a mis recordatorios</a>
+          <div
+            class="bank-card mt-8"
+            data-bank-card
+            role="button"
+            tabindex="0"
+            aria-expanded="false"
+            aria-controls="bank-card-details"
+            aria-label="Mostrar datos bancarios para transferencias"
+          >
+            <div class="bank-card__inner" data-bank-card-inner>
+              <div class="bank-card__face bank-card__face--front">
+                <div class="bank-card__icon">
+                  <i class="fa-solid fa-credit-card"></i>
+                </div>
+                <p class="bank-card__title">Datos bancarios</p>
+                <p class="bank-card__subtitle">Toca para descubrir las CLABE de la lluvia de sobres</p>
+              </div>
+              <div class="bank-card__face bank-card__face--back" id="bank-card-details">
+                <p class="bank-card__title">Transferencias bancarias</p>
+                <p class="bank-card__subtitle">Elige una opción para copiar la CLABE</p>
+                <div class="bank-card__actions" role="group" aria-label="Copiar CLABE bancaria">
+                  <button
+                    type="button"
+                    class="bank-card__copy-button"
+                    data-clabe="072010001847417938"
+                    data-label="Novio"
+                    aria-label="Copiar CLABE del Novio: 072010001847417938"
+                  >
+                    <span class="bank-card__copy-title">Novio</span>
+                    <span class="bank-card__copy-value">072010001847417938</span>
+                    <span class="bank-card__copy-hint">Toca para copiar</span>
+                  </button>
+                  <button
+                    type="button"
+                    class="bank-card__copy-button"
+                    data-clabe="072010008246528052"
+                    data-label="Novia"
+                    aria-label="Copiar CLABE de la Novia: 072010008246528052"
+                  >
+                    <span class="bank-card__copy-title">Novia</span>
+                    <span class="bank-card__copy-value">072010008246528052</span>
+                    <span class="bank-card__copy-hint">Toca para copiar</span>
+                  </button>
+                </div>
+                <p class="bank-card__feedback" data-bank-card-feedback aria-live="polite"></p>
+              </div>
+            </div>
+          </div>
+          <a href="boda_carmen_alfredo.ics" class="mt-10 button button--outline button--sm button--responsive">Añadir a mis recordatorios</a>
         </div>
       </section>
 
@@ -1057,6 +1105,118 @@
           img.addEventListener('load', handleLoad, { once: true });
         }
       });
+
+      const copyTextToClipboard = async text => {
+        const value = typeof text === 'string' ? text.trim() : '';
+        if (!value) return false;
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          try {
+            await navigator.clipboard.writeText(value);
+            return true;
+          } catch (error) {
+            // Fallback to execCommand if direct copy fails
+          }
+        }
+        const textarea = document.createElement('textarea');
+        textarea.value = value;
+        textarea.setAttribute('readonly', '');
+        textarea.style.position = 'absolute';
+        textarea.style.opacity = '0';
+        textarea.style.pointerEvents = 'none';
+        textarea.style.left = '-9999px';
+        document.body.appendChild(textarea);
+        try {
+          textarea.focus({ preventScroll: true });
+        } catch (error) {
+          textarea.focus();
+        }
+        textarea.select();
+        let succeeded = false;
+        try {
+          succeeded = document.execCommand('copy');
+        } catch (error) {
+          succeeded = false;
+        }
+        document.body.removeChild(textarea);
+        return succeeded;
+      };
+
+      const initializeBankCard = () => {
+        const bankCard = document.querySelector('[data-bank-card]');
+        if (!bankCard) return;
+
+        const feedbackElement = bankCard.querySelector('[data-bank-card-feedback]');
+        const copyButtons = bankCard.querySelectorAll('[data-clabe]');
+        let feedbackTimeoutId;
+
+        const setFlipped = isFlipped => {
+          bankCard.classList.toggle('is-flipped', Boolean(isFlipped));
+          bankCard.setAttribute('aria-expanded', isFlipped ? 'true' : 'false');
+        };
+
+        const showFeedback = message => {
+          if (!feedbackElement) return;
+          window.clearTimeout(feedbackTimeoutId);
+          feedbackElement.textContent = message || '';
+          if (message) {
+            feedbackElement.classList.add('is-visible');
+            feedbackTimeoutId = window.setTimeout(() => {
+              feedbackElement.classList.remove('is-visible');
+              feedbackElement.textContent = '';
+            }, 4000);
+          } else {
+            feedbackElement.classList.remove('is-visible');
+          }
+        };
+
+        const toggleFlip = () => {
+          const nextState = !bankCard.classList.contains('is-flipped');
+          setFlipped(nextState);
+          if (!nextState) {
+            showFeedback('');
+          }
+        };
+
+        bankCard.addEventListener('click', event => {
+          if (event.target.closest('[data-clabe]')) {
+            return;
+          }
+          toggleFlip();
+        });
+
+        bankCard.addEventListener('keydown', event => {
+          if (event.target.closest('[data-clabe]')) {
+            return;
+          }
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            toggleFlip();
+          } else if (event.key === 'Escape') {
+            setFlipped(false);
+          }
+        });
+
+        copyButtons.forEach(button => {
+          button.addEventListener('click', async event => {
+            event.stopPropagation();
+            const clabe = (button.dataset.clabe || '').trim();
+            const label = (button.dataset.label || '').trim() || 'la cuenta';
+            if (!clabe) return;
+            const success = await copyTextToClipboard(clabe);
+            if (success) {
+              button.classList.add('is-copied');
+              showFeedback(`CLABE de ${label} copiada al portapapeles.`);
+              window.setTimeout(() => {
+                button.classList.remove('is-copied');
+              }, 1400);
+            } else {
+              showFeedback('No fue posible copiar la CLABE. Inténtalo nuevamente.');
+            }
+          });
+        });
+      };
+
+      initializeBankCard();
 
       // Audio controls
       const audio = document.getElementById('wedding-audio');

--- a/styles.css
+++ b/styles.css
@@ -472,3 +472,167 @@ body {
 .button__icon-gold {
   color: var(--gold);
 }
+
+.bank-card {
+  display: flex;
+  justify-content: center;
+  perspective: 1600px;
+  cursor: pointer;
+}
+
+.bank-card:focus-visible {
+  outline: 3px solid rgba(194, 166, 117, 0.45);
+  outline-offset: 6px;
+}
+
+.bank-card__inner {
+  position: relative;
+  width: 100%;
+  max-width: 26rem;
+  min-height: 18.5rem;
+  transform-style: preserve-3d;
+  transition: transform 0.7s cubic-bezier(0.2, 0.85, 0.4, 1);
+}
+
+.bank-card.is-flipped .bank-card__inner {
+  transform: rotateY(180deg);
+}
+
+.bank-card__face {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2.25rem 2rem;
+  border-radius: 1.75rem;
+  border: 1px solid rgba(194, 166, 117, 0.55);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 32px 72px -44px rgba(47, 79, 79, 0.65);
+  backface-visibility: hidden;
+  text-align: center;
+  pointer-events: none;
+}
+
+.bank-card__face--front {
+  pointer-events: auto;
+}
+
+.bank-card__face--back {
+  transform: rotateY(180deg);
+}
+
+.bank-card.is-flipped .bank-card__face--front {
+  pointer-events: none;
+}
+
+.bank-card.is-flipped .bank-card__face--back {
+  pointer-events: auto;
+}
+
+.bank-card__icon {
+  width: 4rem;
+  height: 4rem;
+  border-radius: 50%;
+  background: rgba(194, 166, 117, 0.2);
+  color: var(--gold);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.8rem;
+  box-shadow: inset 0 0 0 1px rgba(194, 166, 117, 0.3);
+}
+
+.bank-card__title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: rgba(47, 79, 79, 0.92);
+}
+
+.bank-card__subtitle {
+  font-size: 0.95rem;
+  color: rgba(47, 79, 79, 0.65);
+  line-height: 1.55;
+}
+
+.bank-card__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  width: 100%;
+}
+
+@media (min-width: 640px) {
+  .bank-card__actions {
+    flex-direction: row;
+  }
+}
+
+.bank-card__copy-button {
+  flex: 1;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(194, 166, 117, 0.6);
+  background: rgba(250, 247, 242, 0.85);
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--forest);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: background-color 0.25s ease, border-color 0.25s ease,
+    box-shadow 0.25s ease, transform 0.2s ease;
+}
+
+.bank-card__copy-button:hover {
+  transform: translateY(-1px);
+  background: rgba(231, 216, 201, 0.6);
+  border-color: rgba(194, 166, 117, 0.75);
+  box-shadow: 0 20px 42px -32px rgba(47, 79, 79, 0.6);
+}
+
+.bank-card__copy-button:focus-visible {
+  outline: 2px solid rgba(194, 166, 117, 0.75);
+  outline-offset: 4px;
+}
+
+.bank-card__copy-button.is-copied {
+  background: rgba(194, 166, 117, 0.18);
+  border-color: rgba(194, 166, 117, 0.85);
+  box-shadow: 0 18px 40px -30px rgba(47, 79, 79, 0.55);
+}
+
+.bank-card__copy-title {
+  font-size: 0.95rem;
+}
+
+.bank-card__copy-value {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  color: rgba(47, 79, 79, 0.85);
+  word-break: break-all;
+}
+
+.bank-card__copy-hint {
+  font-size: 0.7rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(47, 79, 79, 0.55);
+}
+
+.bank-card__feedback {
+  min-height: 1.25rem;
+  font-size: 0.85rem;
+  color: rgba(47, 79, 79, 0.7);
+  transition: opacity 0.3s ease;
+  opacity: 0;
+}
+
+.bank-card__feedback.is-visible {
+  opacity: 1;
+}


### PR DESCRIPTION
## Summary
- add an interactive bank-details flip card to the "Lluvia de sobres" section with CLABE copy actions for both spouses
- style the new bank card component to match the invitation aesthetics and provide feedback states
- wire the flip behaviour and clipboard fallback logic into the main script

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dc83d4c18483258cc2546481d2c53c