### PR TITLE
Improve bank card layout on small screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -494,6 +494,40 @@ body {
   transition: transform 0.7s cubic-bezier(0.2, 0.85, 0.4, 1);
 }
 
+@media (max-width: 480px) {
+  .bank-card__inner {
+    min-height: 22.5rem;
+  }
+}
+
+@media (max-width: 380px) {
+  .bank-card__inner {
+    min-height: 24rem;
+  }
+
+  .bank-card__face {
+    padding: 2.4rem 1.75rem;
+    gap: 0.85rem;
+  }
+
+  .bank-card__subtitle {
+    font-size: 0.9rem;
+  }
+
+  .bank-card__copy-button {
+    padding: 0.9rem 1.1rem;
+  }
+
+  .bank-card__copy-value {
+    font-size: 0.9rem;
+  }
+
+  .bank-card__copy-hint {
+    font-size: 0.65rem;
+    letter-spacing: 0.18em;
+  }
+}
+
 .bank-card.is-flipped .bank-card__inner {
   transform: rotateY(180deg);
 }


### PR DESCRIPTION
## Summary
- increase the minimum height of the bank card on very small screens to prevent content overflow
- tweak padding and typography inside the card for narrow viewports so text and buttons remain legible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc873061ec8325b7cb5eef4266af67