### PR TITLE
Fix bank card container height for mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -487,24 +487,15 @@ body {
 
 .bank-card__inner {
   position: relative;
+  display: grid;
+  grid-template-columns: 1fr;
   width: 100%;
   max-width: 26rem;
-  min-height: 18.5rem;
   transform-style: preserve-3d;
   transition: transform 0.7s cubic-bezier(0.2, 0.85, 0.4, 1);
 }
 
-@media (max-width: 480px) {
-  .bank-card__inner {
-    min-height: 22.5rem;
-  }
-}
-
 @media (max-width: 380px) {
-  .bank-card__inner {
-    min-height: 24rem;
-  }
-
   .bank-card__face {
     padding: 2.4rem 1.75rem;
     gap: 0.85rem;
@@ -533,8 +524,7 @@ body {
 }
 
 .bank-card__face {
-  position: absolute;
-  inset: 0;
+  grid-area: 1 / 1;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## Summary
- update the bank card container to use a grid layout so its height adapts to content
- remove hard-coded mobile min-heights to prevent overflow on iPhone

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc88dc1c5483258e9280148ff18e1d