### PR TITLE
Ensure CLABE numbers stay on one line

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -637,9 +637,9 @@ body {
 .bank-card__copy-value {
   font-family: 'Courier New', Courier, monospace;
   font-size: 0.95rem;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.04em;
   color: rgba(47, 79, 79, 0.85);
-  word-break: break-all;
+  white-space: nowrap;
 }
 
 .bank-card__copy-hint {


### PR DESCRIPTION
## Summary
- reduce the letter spacing on the CLABE value styling so the digits stay within the button width
- enforce no wrapping on CLABE numbers to keep them on a single line across viewports

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc8b1f486483258b4483a563234fa9