### PR TITLE
Add rotating entrance animation for section reveals

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -130,13 +130,16 @@ body {
 
 .reveal {
   opacity: 0;
-  transform: translateY(14px);
-  transition: opacity 0.6s ease, transform 0.6s ease;
+  transform-origin: bottom center;
+  transform: perspective(1200px) rotateX(22deg) translateY(48px);
+  transition: opacity 0.6s ease, transform 0.85s cubic-bezier(0.19, 1, 0.22, 1);
+  will-change: transform, opacity;
+  backface-visibility: hidden;
 }
 
 .reveal.reveal-visible {
   opacity: 1;
-  transform: translateY(0);
+  transform: perspective(1200px) rotateX(0deg) translateY(0);
 }
 
 .blur-up {
@@ -313,6 +316,12 @@ body {
   .mobile-action-bar,
   .blur-up {
     transition: none;
+  }
+
+  .reveal,
+  .reveal.reveal-visible {
+    opacity: 1;
+    transform: none !important;
   }
 }
 


### PR DESCRIPTION
## Summary
- update the section reveal animation to rotate upward as it enters from the bottom
- honor reduced-motion preferences by removing the rotation and transition when requested

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc8f19d1188325954ec707b0dbe969