### PR TITLE
feat: load guests from Google Sheets CSV

### DIFF
--- a/admin-invitados.html
+++ b/admin-invitados.html
@@ -4,6 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Admin de invitados – Slugs & WhatsApp</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Playfair+Display:wght@400;500;600&display=swap" rel="stylesheet">
   <style>
     :root {
       color-scheme: light;
@@ -18,6 +21,16 @@
       display: flex;
       flex-direction: column;
       background: #f8f9fb;
+    }
+
+    .hidden {
+      display: none !important;
+    }
+
+    @keyframes spin {
+      to {
+        transform: rotate(360deg);
+      }
     }
 
     header {
@@ -218,18 +231,50 @@
     }
 
     .status-bar {
+      margin-top: 0.75rem;
       font-size: 0.9rem;
-      color: #475569;
-      min-height: 1.2rem;
-      margin-bottom: 0.75rem;
+      color: #334155;
+      background: #e2e8f0;
+      border-radius: 0.8rem;
+      padding: 0.6rem 0.9rem;
+      line-height: 1.4;
     }
 
     .status-bar.error {
       color: #b91c1c;
+      background: #fee2e2;
+      border: 1px solid rgba(185, 28, 28, 0.35);
     }
 
     .status-bar.success {
       color: #047857;
+      background: #dcfce7;
+      border: 1px solid rgba(4, 120, 87, 0.35);
+    }
+
+    .status-bar.warning {
+      color: #b45309;
+      background: #fef3c7;
+      border: 1px solid rgba(180, 83, 9, 0.35);
+    }
+
+    .alert-banner {
+      margin-top: 0.75rem;
+      font-size: 0.9rem;
+      color: #b91c1c;
+      background: #fee2e2;
+      border: 1px solid rgba(185, 28, 28, 0.35);
+      border-radius: 0.75rem;
+      padding: 0.7rem 0.95rem;
+      line-height: 1.4;
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+    }
+
+    .alert-banner::before {
+      content: '⚠️';
+      font-size: 1rem;
     }
 
     .counters {
@@ -458,9 +503,35 @@
       gap: 0.4rem;
     }
 
-    .name {
-      font-weight: 600;
+    .guest-name {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 0.15rem;
+      margin-bottom: 0.4rem;
+    }
+
+    .guest-name-first {
+      font-family: 'Great Vibes', 'Segoe Script', cursive;
+      font-size: 1.4rem;
+      line-height: 1.1;
+      letter-spacing: 0.02em;
       color: #0f172a;
+      text-align: center;
+    }
+
+    .guest-name-last {
+      font-family: 'Playfair Display', 'Cormorant Garamond', 'Montserrat', serif;
+      font-size: 0.95rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #1f2937;
+      text-align: center;
+    }
+
+    .guest-name-last:empty::after {
+      content: '\00a0';
     }
 
     .note {
@@ -508,6 +579,30 @@
       text-align: center;
       color: #64748b;
       font-style: italic;
+    }
+
+    .table-message {
+      text-align: center;
+      color: #475569;
+      font-size: 0.95rem;
+    }
+
+    .table-message.loading {
+      position: relative;
+      color: #1d4ed8;
+    }
+
+    .table-message.loading::after {
+      content: '';
+      display: inline-block;
+      width: 1.1rem;
+      height: 1.1rem;
+      border-radius: 999px;
+      border: 2px solid rgba(29, 78, 216, 0.25);
+      border-top-color: #1d4ed8;
+      margin-left: 0.6rem;
+      animation: spin 0.9s linear infinite;
+      vertical-align: middle;
     }
 
     .chip {
@@ -711,8 +806,8 @@
         <label for="base-url-input">Base URL del sitio
           <input id="base-url-input" type="url" value="https://boda-cya.github.io/" placeholder="https://ejemplo.com/">
         </label>
-        <label for="json-path-input">Ruta del JSON
-          <input id="json-path-input" type="text" value="./data/invitados.json" placeholder="./data/invitados.json">
+        <label for="json-path-input">Ruta del CSV
+          <input id="json-path-input" type="text" value="https://docs.google.com/spreadsheets/d/e/2PACX-1vQaEems58aHqiFhnfx7Mf0nOy3hgFbts1U-3BseX9tZKFoVds7YOpjMos8do9Q_9WDwZ8bHXvW0d19A/pub?gid=1822023372&amp;single=true&amp;output=csv" placeholder="URL del CSV público">
         </label>
         <label for="search-input">Búsqueda
           <input id="search-input" type="text" placeholder="Buscar por nombre, slug o WhatsApp">
@@ -736,12 +831,13 @@ Confirma tu asistencia aquí: {url}</textarea>
         </label>
       </div>
       <div class="actions primary-actions">
-        <button id="fetch-button" type="button">Cargar JSON</button>
+        <button id="fetch-button" type="button">Cargar CSV</button>
         <button id="file-button" type="button" class="secondary">Cargar archivo…</button>
         <input id="file-input" type="file" accept="application/json" style="display:none">
       </div>
     </details>
     <div class="status-bar" id="status-text">Listo.</div>
+    <div class="alert-banner hidden" id="error-banner" role="status" aria-live="polite"></div>
     <div class="counters">
       <span>Total: <strong id="total-count">0</strong></span>
       <span>Con WhatsApp: <strong id="with-whatsapp-count">0</strong></span>
@@ -763,7 +859,7 @@ Confirma tu asistencia aquí: {url}</textarea>
         </thead>
         <tbody id="guest-table-body">
           <tr class="table-message">
-            <td class="table-empty" colspan="5">Sin datos. Carga el JSON.</td>
+            <td class="table-empty" colspan="5">Sin datos. Carga el CSV.</td>
           </tr>
         </tbody>
       </table>
@@ -803,10 +899,24 @@ Confirma tu asistencia aquí: {url}</textarea>
       </div>
     </aside>
   </div>
-</main>
+  </main>
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js" integrity="sha256-td24kTx5cDIeEJD7BqXc9E+u6KDAdAm8YGtS+wGGyR0=" crossorigin="anonymous"></script>
   <script src="scripts/message-utils.js"></script>
   <script>
     const messaging = window.InvitationMessaging || {};
+
+    const SHEET_CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vQaEems58aHqiFhnfx7Mf0nOy3hgFbts1U-3BseX9tZKFoVds7YOpjMos8do9Q_9WDwZ8bHXvW0d19A/pub?gid=1822023372&single=true&output=csv';
+    const FALLBACK_JSON_URL = './data/invitados.json';
+    const CSV_HEADER_ALIASES = {
+      slug: ['slug', 'identificador', 'id', 'codigo', 'code', 'sluginvitado'],
+      displayName: ['displayname', 'nombre', 'nombrecompleto', 'nombreyapellidos', 'invitado', 'nombreinvitado'],
+      relation: ['relation', 'relacion', 'parentesco', 'categoria'],
+      treatment: ['treatment', 'trato', 'tratamiento', 'tipoinvitacion', 'tipo', 'modalidad'],
+      seats: ['seats', 'lugares', 'pases', 'pase', 'asientos', 'cupos'],
+      whatsapp: ['whatsapp', 'telefono', 'tel', 'celular', 'mobile', 'phone', 'whats'],
+      note: ['note', 'nota', 'comentario', 'comentarios', 'observaciones']
+    };
+    const SEARCH_DEBOUNCE_MS = 250;
 
     const state = {
       guests: [],
@@ -815,7 +925,8 @@ Confirma tu asistencia aquí: {url}</textarea>
       template: document.getElementById('template-input').value,
       searchTerm: '',
       filter: 'all',
-      selectedSlug: ''
+      selectedSlug: '',
+      isLoading: false
     };
 
     const dataControls = document.getElementById('data-controls');
@@ -838,7 +949,9 @@ Confirma tu asistencia aquí: {url}</textarea>
     }
 
     const statusText = document.getElementById('status-text');
+    const errorBanner = document.getElementById('error-banner');
     const tableBody = document.getElementById('guest-table-body');
+    const searchInput = document.getElementById('search-input');
 
     const previewElements = {
       content: document.querySelector('[data-preview-content]'),
@@ -859,11 +972,35 @@ Confirma tu asistencia aquí: {url}</textarea>
     };
 
     function setStatus(message, type = '') {
+      if (!statusText) return;
       statusText.textContent = message;
       statusText.className = 'status-bar';
       if (type) {
         statusText.classList.add(type);
       }
+    }
+
+    function showErrorBanner(message) {
+      if (!errorBanner) return;
+      if (message) {
+        errorBanner.textContent = message;
+        errorBanner.classList.remove('hidden');
+      } else {
+        errorBanner.textContent = '';
+        errorBanner.classList.add('hidden');
+      }
+    }
+
+    function hideErrorBanner() {
+      showErrorBanner('');
+    }
+
+    function debounce(fn, delay = SEARCH_DEBOUNCE_MS) {
+      let timeoutId;
+      return function (...args) {
+        clearTimeout(timeoutId);
+        timeoutId = setTimeout(() => fn.apply(this, args), delay);
+      };
     }
 
     function escapeHtml(text) {
@@ -875,63 +1012,203 @@ Confirma tu asistencia aquí: {url}</textarea>
         .replace(/'/g, '&#39;');
     }
 
-    function normalizeBaseUrl(value) {
-      if (messaging.normalizeBaseUrl) {
-        return messaging.normalizeBaseUrl(value);
-      }
-      if (!value) return '';
-      return value.trim().replace(/\/+$/g, '');
+    function withCacheBusting(url) {
+      if (!url) return '';
+      const separator = url.includes('?') ? '&' : '?';
+      return `${url}${separator}cb=${Date.now()}`;
     }
 
-    function normalizeWhatsappFallback(raw) {
+    function normalizeKey(text) {
+      return text
+        ? String(text)
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .toLowerCase()
+            .replace(/[^a-z0-9]/g, '')
+        : '';
+    }
+
+    function transformCsvHeader(header) {
+      const normalized = normalizeKey(header);
+      for (const key of Object.keys(CSV_HEADER_ALIASES)) {
+        if (CSV_HEADER_ALIASES[key].includes(normalized)) {
+          return key;
+        }
+      }
+      return normalized || header;
+    }
+
+    function readField(entry, field) {
+      if (!entry || typeof entry !== 'object') {
+        return undefined;
+      }
+      if (Object.prototype.hasOwnProperty.call(entry, field)) {
+        return entry[field];
+      }
+      const target = normalizeKey(field);
+      for (const key of Object.keys(entry)) {
+        if (normalizeKey(key) === target) {
+          return entry[key];
+        }
+      }
+      return undefined;
+    }
+
+    function removeDiacritics(text) {
+      return text.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    }
+
+    function slugify(value) {
+      if (!value) return '';
+      return removeDiacritics(String(value))
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9\s-]/g, '')
+        .replace(/\s+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-+|-+$/g, '');
+    }
+
+    function normalizeRelation(value) {
+      if (typeof messaging.normalizeRelation === 'function') {
+        const normalized = messaging.normalizeRelation(value);
+        if (normalized) {
+          return normalized;
+        }
+      }
+      const text = String(value || '').toLowerCase();
+      if (text.includes('fam')) return 'familia';
+      if (text.includes('amig') || text.includes('coleg') || text.includes('trab')) return 'amigo';
+      if (!text) return 'amigo';
+      return text.includes('fam') ? 'familia' : 'amigo';
+    }
+
+    function normalizeTreatment(value) {
+      if (typeof messaging.normalizeTreatment === 'function') {
+        const normalized = messaging.normalizeTreatment(value);
+        if (normalized) {
+          return normalized;
+        }
+      }
+      const text = String(value || '').toLowerCase();
+      if (text.includes('grup')) return 'grupal';
+      if (text.includes('acom') || text.includes('pareja') || text.includes('doble')) return 'acompanado';
+      if (text.includes('indi') || text.includes('solo')) return 'individual';
+      return 'individual';
+    }
+
+    function normalizeSeats(value) {
+      if (value === null || value === undefined || value === '') {
+        return 1;
+      }
+      const numeric = typeof value === 'number' && Number.isFinite(value)
+        ? value
+        : Number.parseInt(String(value).replace(/[^0-9-]/g, ''), 10);
+      if (!Number.isFinite(numeric)) {
+        return 1;
+      }
+      return Math.max(1, Math.round(numeric));
+    }
+
+    function normalizeWhatsapp(raw) {
+      if (typeof messaging.normalizeWhatsapp === 'function') {
+        const normalized = messaging.normalizeWhatsapp(raw);
+        if (normalized) {
+          return normalized;
+        }
+      }
       if (!raw) return null;
       const digits = String(raw).replace(/\D/g, '');
-      if (digits.length < 10) return null;
-      const local = digits.slice(-10);
-      const country = '52';
+      if (!digits) return null;
+      let number = '';
+      if (digits.length === 10) {
+        number = `52${digits}`;
+      } else if (digits.length === 12 && digits.startsWith('52')) {
+        number = digits;
+      } else {
+        return null;
+      }
+      const local = number.slice(-10);
+      const country = number.slice(0, number.length - 10) || '52';
+      const display = `+${country} ${local.replace(/(\d{3})(\d{3})(\d{4})/, '$1 $2 $3')}`;
       return {
-        wa: `${country}${local}`,
-        e164: `+${country}${local}`,
-        display: `+${country} ${local.replace(/(\d{3})(\d{3})(\d{4})/, '$1 $2 $3')}`,
-        digits: `${country}${local}`
+        wa: number,
+        e164: `+${number}`,
+        display,
+        digits: number
       };
     }
 
-    function sanitizeGuest(entry) {
-      if (!entry || typeof entry !== 'object') return null;
-      const slug = typeof entry.slug === 'string' ? entry.slug.trim() : '';
-      if (!slug) return null;
+    function deriveNames(displayName) {
+      const parts = displayName.split(/\s+/).filter(Boolean);
+      const nombre = parts[0] || '';
+      const apellidos = parts.slice(1).join(' ');
+      return { nombre, apellidos };
+    }
 
-      const seatsNumber = Number(entry.seats);
-      const relation = messaging.normalizeRelation
-        ? messaging.normalizeRelation(entry.relation)
-        : (String(entry.relation || '').trim().toLowerCase() === 'familia' ? 'familia' : 'amigo');
-      const rawTreatment = messaging.normalizeTreatment
-        ? messaging.normalizeTreatment(entry.treatment)
-        : String(entry.treatment || '').trim().toLowerCase();
-      const treatment = rawTreatment === 'grupal' || rawTreatment === 'acompanado' || rawTreatment === 'individual'
-        ? rawTreatment
-        : 'individual';
-      const normalizedWhatsapp = messaging.normalizeWhatsapp
-        ? messaging.normalizeWhatsapp(entry.whatsapp)
-        : normalizeWhatsappFallback(entry.whatsapp);
+    function normalizeGuest(entry) {
+      if (!entry || typeof entry !== 'object') return null;
+      const rawDisplay = readField(entry, 'displayName');
+      const displayName = rawDisplay !== undefined && rawDisplay !== null
+        ? String(rawDisplay).toUpperCase().trim()
+        : '';
+      if (!displayName) {
+        return null;
+      }
+
+      const rawSlug = readField(entry, 'slug');
+      const cleanedSlug = slugify(rawSlug);
+      const generatedSlug = slugify(displayName);
+      const slug = cleanedSlug || generatedSlug;
+      if (!slug) {
+        return null;
+      }
+
+      const relation = normalizeRelation(readField(entry, 'relation'));
+      const treatment = normalizeTreatment(readField(entry, 'treatment'));
+      const seats = normalizeSeats(readField(entry, 'seats'));
+      const rawWhatsapp = readField(entry, 'whatsapp');
+      const normalizedWhatsapp = normalizeWhatsapp(rawWhatsapp);
+      const whatsapp = rawWhatsapp !== undefined && rawWhatsapp !== null
+        ? String(rawWhatsapp).trim()
+        : '';
+      const noteRaw = readField(entry, 'note');
+      const note = typeof noteRaw === 'string' ? noteRaw.trim() : '';
+      const { nombre, apellidos } = deriveNames(displayName);
 
       return {
         slug,
-        displayName: typeof entry.displayName === 'string' ? entry.displayName.trim() : '',
+        displayName,
         relation,
         treatment,
-        seats: Number.isFinite(seatsNumber) && seatsNumber > 0 ? seatsNumber : null,
-        note: typeof entry.note === 'string' ? entry.note.trim() : '',
-        whatsapp: typeof entry.whatsapp === 'string' ? entry.whatsapp.trim() : '',
-        normalizedWhatsapp
+        seats,
+        whatsapp,
+        normalizedWhatsapp,
+        note,
+        nombre,
+        apellidos
       };
     }
 
-    function applyGuests(data) {
-      state.guests = data.map(sanitizeGuest).filter(Boolean);
-      state.selectedSlug = state.guests.length ? state.guests[0].slug : '';
+    function commitGuests(normalizedGuests) {
+      const sorted = [...normalizedGuests].sort((a, b) =>
+        a.displayName.localeCompare(b.displayName, 'es', { sensitivity: 'base' })
+      );
+      state.guests = sorted;
+      if (!sorted.length) {
+        state.selectedSlug = '';
+      } else {
+        const current = sorted.find((guest) => guest.slug === state.selectedSlug);
+        state.selectedSlug = current ? current.slug : sorted[0].slug;
+      }
       renderTable();
+    }
+
+    function applyGuests(data) {
+      const normalized = Array.isArray(data)
+        ? data.map(normalizeGuest).filter(Boolean)
+        : [];
+      commitGuests(normalized);
     }
 
     function updateCounters() {
@@ -962,7 +1239,9 @@ Confirma tu asistencia aquí: {url}</textarea>
           guest.normalizedWhatsapp ? guest.normalizedWhatsapp.e164 : '',
           guest.normalizedWhatsapp ? guest.normalizedWhatsapp.digits : '',
           guest.relation || '',
-          guest.treatment || ''
+          guest.treatment || '',
+          guest.nombre || '',
+          guest.apellidos || ''
         ].join(' ').toLowerCase();
         return haystack.includes(term);
       });
@@ -980,6 +1259,14 @@ Confirma tu asistencia aquí: {url}</textarea>
         individual: 'Individual'
       };
       return labels[value] || '';
+    }
+
+    function normalizeBaseUrl(value) {
+      if (messaging.normalizeBaseUrl) {
+        return messaging.normalizeBaseUrl(value);
+      }
+      if (!value) return '';
+      return value.trim().replace(/\/+$/g, '');
     }
 
     function getBaseUrl() {
@@ -1040,6 +1327,11 @@ Confirma tu asistencia aquí: {url}</textarea>
 
     function updatePreview() {
       if (!previewElements.content || !previewElements.empty) return;
+      if (state.isLoading) {
+        previewElements.content.classList.add('hidden');
+        previewElements.empty.classList.remove('hidden');
+        return;
+      }
       const guest = state.guests.find((item) => item.slug === state.selectedSlug);
       if (!guest) {
         previewElements.content.classList.add('hidden');
@@ -1135,13 +1427,24 @@ Confirma tu asistencia aquí: {url}</textarea>
     }
 
     function renderTable() {
+      if (!tableBody) return;
       const guests = getFilteredGuests();
       tableBody.innerHTML = '';
+
+      if (state.isLoading) {
+        const row = document.createElement('tr');
+        row.classList.add('table-message');
+        row.innerHTML = '<td class="table-empty table-message loading" colspan="5">Cargando invitad@s…</td>';
+        tableBody.appendChild(row);
+        updateCounters();
+        updatePreview();
+        return;
+      }
 
       if (!state.guests.length) {
         const row = document.createElement('tr');
         row.classList.add('table-message');
-        row.innerHTML = '<td class="table-empty" colspan="5">Sin datos. Carga el JSON.</td>';
+        row.innerHTML = '<td class="table-empty" colspan="5">Sin datos. Carga el CSV.</td>';
         tableBody.appendChild(row);
         state.selectedSlug = '';
         updateCounters();
@@ -1187,10 +1490,16 @@ Confirma tu asistencia aquí: {url}</textarea>
         const whatsappCell = guest.normalizedWhatsapp
           ? `<div>${escapeHtml(guest.normalizedWhatsapp.display)}</div><span class="badge ok">ok</span>`
           : '<span class="badge warning">Sin número</span>';
+        const nameBlock = `
+          <div class="guest-name">
+            <span class="guest-name-first">${escapeHtml(guest.nombre || guest.displayName || 'Invitad@')}</span>
+            <span class="guest-name-last">${escapeHtml(guest.apellidos || '')}</span>
+          </div>
+        `.trim();
 
         row.innerHTML = `
           <td data-label="Nombre">
-            <span class="name">${escapeHtml(guest.displayName || 'Invitad@')}</span>
+            ${nameBlock}
             ${chipsHtml}
             ${noteHtml}
           </td>
@@ -1213,7 +1522,7 @@ Confirma tu asistencia aquí: {url}</textarea>
             </button>
             <button type="button" data-action="whatsapp-guest" data-slug="${encodeURIComponent(guest.slug)}" ${guestWhatsappLink ? '' : 'disabled'} aria-label="Enviar por WhatsApp" title="Enviar por WhatsApp">
               <svg class="button-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path d="M.057 24l1.687-6.163A11.88 11.88 0 0 1 0 11.887C.003 5.326 5.38 0 12.004 0a11.86 11.86 0 0 1 8.44 3.49 11.83 11.83 0 0 1 3.497 8.425C23.938 18.579 18.563 24 11.936 24c-1.99-.001-3.951-.5-5.688-1.448zm6.597-3.807a9.78 9.78 0 0 0 5.282 1.533c5.448 0 9.886-4.434 9.889-9.885.002-5.462-4.415-9.89-9.881-9.894-5.452 0-9.887 4.434-9.889 9.884-.001 2.225.651 3.891 1.746 5.634l-.999 3.648zm11.387-5.464c-.074-.123-.272-.198-.57-.347-.297-.149-1.758-.868-2.031-.967-.272-.099-.47-.149-.669.149-.198.297-.768.967-.941 1.165-.173.198-.347.223-.644.074-.297-.149-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.297-.347.446-.521.149-.174.198-.298.297-.497.099-.198.05-.372-.025-.521-.074-.149-.669-1.611-.916-2.207-.242-.579-.487-.5-.669-.51l-.57-.01c-.198 0-.52.074-.792.372s-1.04 1.016-1.04 2.479 1.065 2.876 1.213 3.074c.149.198 2.095 3.2 5.076 4.487.709.306 1.262.489 1.694.626.712.227 1.36.195 1.872.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413z" fill="currentColor" />
+                <path d="M.057 24l1.687-6.163A11.88 11.88 0 0 1 0 11.887C.003 5.326 5.38 0 12.004 0a11.86 11.86 0 0 1 8.44 3.491 11.83 11.83 0 0 1 3.497 8.425C23.938 18.579 18.563 24 11.936 24c-1.99-.001-3.951-.5-5.688-1.448zm6.597-3.807a9.78 9.78 0 0 0 5.282 1.533c5.448 0 9.886-4.434 9.889-9.885.002-5.462-4.415-9.89-9.881-9.894-5.452 0-9.887 4.434-9.889 9.884-.001 2.225.651 3.891 1.746 5.634l-.999 3.648zm11.387-5.464c-.074-.123-.272-.198-.57-.347-.297-.149-1.758-.868-2.031-.967-.272-.099-.47-.149-.669.149-.198.297-.768.967-.941 1.165-.173.198-.347.223-.644.074-.297-.149-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.297-.347.446-.521.149-.174.198-.298.297-.497.099-.198.05-.372-.025-.521-.074-.149-.669-1.611-.916-2.207-.242-.579-.487-.5-.669-.51l-.57-.01c-.198 0-.52.074-.792.372s-1.04 1.016-1.04 2.479 1.065 2.876 1.213 3.074c.149.198 2.095 3.2 5.076 4.487.709.306 1.262.489 1.694.626.712.227 1.36.195 1.872.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413z" fill="currentColor" />
               </svg>
               <span class="button-text">Enviar WhatsApp</span>
             </button>
@@ -1250,10 +1559,56 @@ Confirma tu asistencia aquí: {url}</textarea>
       return success;
     }
 
-    async function fetchGuests(path) {
+    async function fetchGuestsFromCsv(url) {
+      const targetUrl = url || SHEET_CSV_URL;
+      if (!targetUrl) {
+        setStatus('Ingresa la ruta del CSV.', 'error');
+        return;
+      }
+
+      setLoading(true);
+      hideErrorBanner();
+
       try {
         setStatus('Cargando invitad@s…');
-        const response = await fetch(path, { cache: 'no-store' });
+        const response = await fetch(withCacheBusting(targetUrl), { cache: 'no-store' });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const csvText = await response.text();
+        if (typeof Papa === 'undefined' || typeof Papa.parse !== 'function') {
+          throw new Error('PapaParse no está disponible.');
+        }
+        const parsed = Papa.parse(csvText, {
+          header: true,
+          skipEmptyLines: 'greedy',
+          transformHeader: transformCsvHeader
+        });
+        const normalizedGuests = Array.isArray(parsed.data)
+          ? parsed.data.map(normalizeGuest).filter(Boolean)
+          : [];
+        if (!normalizedGuests.length) {
+          throw new Error('El CSV no contiene registros válidos.');
+        }
+        commitGuests(normalizedGuests);
+        hideErrorBanner();
+        setStatus('Datos cargados desde Google Sheets.', 'success');
+      } catch (error) {
+        console.error(error);
+        showErrorBanner('No se pudo cargar el CSV de Google Sheets. Intenta recargar la página.');
+        setStatus('No se pudo cargar el CSV de Google Sheets. Intenta recargar la página.', 'error');
+        const fallbackLoaded = await fetchFallbackJson();
+        if (fallbackLoaded) {
+          setStatus('Datos cargados desde invitados.json (fallback local).', 'warning');
+        }
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    async function fetchFallbackJson() {
+      try {
+        const response = await fetch(withCacheBusting(FALLBACK_JSON_URL), { cache: 'no-store' });
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}`);
         }
@@ -1262,15 +1617,16 @@ Confirma tu asistencia aquí: {url}</textarea>
           throw new Error('El JSON debe ser un arreglo de invitados.');
         }
         applyGuests(data);
-        setStatus('Datos cargados desde el servidor.', 'success');
+        return true;
       } catch (error) {
-        console.error(error);
-        setStatus('Error al cargar JSON. Revisa la ruta o intenta con "Cargar archivo…"', 'error');
+        console.error('Fallback JSON error:', error);
+        return false;
       }
     }
 
     function loadFromFile(file) {
       const reader = new FileReader();
+      setLoading(true);
       reader.onload = (event) => {
         try {
           const text = event.target.result;
@@ -1279,62 +1635,89 @@ Confirma tu asistencia aquí: {url}</textarea>
             throw new Error('El JSON debe ser un arreglo de invitados.');
           }
           applyGuests(data);
+          hideErrorBanner();
           setStatus(`Datos cargados desde archivo: ${file.name}`, 'success');
         } catch (error) {
           console.error(error);
           setStatus('No se pudo leer el archivo seleccionado.', 'error');
+        } finally {
+          setLoading(false);
         }
       };
       reader.onerror = () => {
         setStatus('Error al leer el archivo.', 'error');
+        setLoading(false);
       };
       reader.readAsText(file);
     }
 
-    document.getElementById('fetch-button').addEventListener('click', () => {
-      state.jsonPath = document.getElementById('json-path-input').value.trim();
-      if (!state.jsonPath) {
-        setStatus('Ingresa la ruta del JSON.', 'error');
-        return;
-      }
-      fetchGuests(state.jsonPath);
-    });
+    const fetchButton = document.getElementById('fetch-button');
+    if (fetchButton) {
+      fetchButton.addEventListener('click', () => {
+        const input = document.getElementById('json-path-input');
+        const value = input ? input.value.trim() : '';
+        state.jsonPath = value || SHEET_CSV_URL;
+        fetchGuestsFromCsv(state.jsonPath);
+      });
+    }
 
-    document.getElementById('file-button').addEventListener('click', () => {
-      document.getElementById('file-input').click();
-    });
+    const fileButton = document.getElementById('file-button');
+    const fileInput = document.getElementById('file-input');
+    if (fileButton && fileInput) {
+      fileButton.addEventListener('click', () => {
+        fileInput.click();
+      });
 
-    document.getElementById('file-input').addEventListener('change', (event) => {
-      const file = event.target.files && event.target.files[0];
-      if (file) {
-        loadFromFile(file);
-      }
-      event.target.value = '';
-    });
+      fileInput.addEventListener('change', (event) => {
+        const file = event.target.files && event.target.files[0];
+        if (file) {
+          loadFromFile(file);
+        }
+        event.target.value = '';
+      });
+    }
 
-    document.getElementById('base-url-input').addEventListener('input', (event) => {
-      state.baseUrl = event.target.value.trim();
-      renderTable();
-    });
+    const baseUrlInput = document.getElementById('base-url-input');
+    if (baseUrlInput) {
+      baseUrlInput.addEventListener('input', (event) => {
+        state.baseUrl = event.target.value.trim();
+        renderTable();
+      });
+    }
 
-    document.getElementById('json-path-input').addEventListener('input', (event) => {
-      state.jsonPath = event.target.value.trim();
-    });
+    const jsonPathInput = document.getElementById('json-path-input');
+    if (jsonPathInput) {
+      jsonPathInput.addEventListener('input', (event) => {
+        state.jsonPath = event.target.value.trim();
+      });
+    }
 
-    document.getElementById('template-input').addEventListener('input', (event) => {
-      state.template = event.target.value;
-      renderTable();
-    });
+    const templateInput = document.getElementById('template-input');
+    if (templateInput) {
+      templateInput.addEventListener('input', (event) => {
+        state.template = event.target.value;
+        renderTable();
+      });
+    }
 
-    document.getElementById('search-input').addEventListener('input', (event) => {
-      state.searchTerm = event.target.value;
-      renderTable();
-    });
+    if (searchInput) {
+      const handleSearchInput = debounce((value) => {
+        state.searchTerm = value;
+        renderTable();
+      }, SEARCH_DEBOUNCE_MS);
 
-    document.getElementById('filter-select').addEventListener('change', (event) => {
-      state.filter = event.target.value;
-      renderTable();
-    });
+      searchInput.addEventListener('input', (event) => {
+        handleSearchInput(event.target.value);
+      });
+    }
+
+    const filterSelect = document.getElementById('filter-select');
+    if (filterSelect) {
+      filterSelect.addEventListener('change', (event) => {
+        state.filter = event.target.value;
+        renderTable();
+      });
+    }
 
     tableBody.addEventListener('click', async (event) => {
       const row = event.target.closest('tr[data-slug]');
@@ -1411,9 +1794,7 @@ Confirma tu asistencia aquí: {url}</textarea>
     });
 
     renderTable();
-    if (state.jsonPath) {
-      fetchGuests(state.jsonPath);
-    }
+    fetchGuestsFromCsv(state.jsonPath || SHEET_CSV_URL);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fetch guests from the published Google Sheets CSV with PapaParse and keep a local JSON fallback if the sheet is unavailable
- normalize incoming data (slug generation, whatsapp formatting, seat defaults) and derive name/surname rendering with new typography
- add loading feedback, an error banner, and debounced search while preserving existing table actions and filters

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc94176e68832597256c4e495c6808