### PR TITLE
Split guest names into separate lines and adjust invitation heading

### DIFF
--- a/admin-invitados.html
+++ b/admin-invitados.html
@@ -1388,9 +1388,26 @@ Confirma tu asistencia aquí: {url}</textarea>
       previewElements.empty.classList.add('hidden');
       previewElements.content.classList.remove('hidden');
 
-      const heading = message.heading || (guest.displayName ? `Invitación para ${guest.displayName}` : 'Invitación personalizada');
+      const headingBase = message.heading || 'Invitación para:';
+      const previewFullName = [
+        typeof message.firstName === 'string' ? message.firstName.trim() : '',
+        typeof message.lastName === 'string' ? message.lastName.trim() : '',
+        !message.firstName && !message.lastName && typeof guest.nombre === 'string' ? guest.nombre.trim() : '',
+        !message.firstName && !message.lastName && typeof guest.apellidos === 'string' ? guest.apellidos.trim() : ''
+      ]
+        .filter(Boolean)
+        .join(' ');
+      const fallbackDisplayName = guest.displayName ? guest.displayName.trim() : '';
+      const descriptiveHeading =
+        headingBase === 'Invitación especial'
+          ? headingBase
+          : previewFullName
+              ? `${headingBase} ${previewFullName}`.trim()
+              : fallbackDisplayName
+                ? `${headingBase} ${fallbackDisplayName}`.trim()
+                : headingBase;
       if (previewElements.heading) {
-        previewElements.heading.textContent = heading;
+        previewElements.heading.textContent = descriptiveHeading;
       }
 
       setChip(previewElements.relation, formatRelation(message.relation || guest.relation));

--- a/index.html
+++ b/index.html
@@ -998,8 +998,15 @@
           inviteeLastName !== undefined ? inviteeLastName : lastName
         );
 
+        const headingText = heading || 'Invitación para:';
+        const fullDisplayName = [resolvedFirstName, resolvedLastName]
+          .filter(Boolean)
+          .join(' ')
+          .trim();
+        const fallbackTitleName = fullDisplayName || formatTitleCaseName(displayNameSource);
+
         if (invitationElements.heading) {
-          invitationElements.heading.textContent = heading || `Invitación para ${name}`;
+          invitationElements.heading.textContent = headingText;
         }
         if (invitationElements.personalizedLabel) {
           const labelText = invitationTypeLabel || 'Invitación: Individual';
@@ -1074,14 +1081,20 @@
 
         toggleHidden(invitationElements.generic, true);
         toggleHidden(invitationElements.personalized, false);
+        const descriptiveTitle =
+          headingText === 'Invitación especial'
+            ? headingText
+            : fallbackTitleName
+              ? `${headingText} ${fallbackTitleName}`.trim()
+              : headingText;
         if (invitationElements.brand) {
-          if (heading) {
-            invitationElements.brand.setAttribute('title', heading);
+          if (descriptiveTitle) {
+            invitationElements.brand.setAttribute('title', descriptiveTitle);
           } else {
             invitationElements.brand.removeAttribute('title');
           }
         }
-        document.title = heading ? `${heading} · ${originalTitle}` : originalTitle;
+        document.title = descriptiveTitle ? `${descriptiveTitle} · ${originalTitle}` : originalTitle;
         setCardState('personalized');
 
       };
@@ -1164,7 +1177,7 @@
         const note = normalizedString(entry.note);
         const whatsapp = normalizeWhatsappValue(entry.whatsapp);
 
-        return {
+        const inviteeRecord = {
           slug,
           displayName,
           relation,
@@ -1174,6 +1187,15 @@
           whatsapp,
           tokens: extractTokens(entry)
         };
+
+        if (firstNameSource) {
+          inviteeRecord.nombre = firstNameSource;
+        }
+        if (lastNameSource) {
+          inviteeRecord.apellidos = lastNameSource;
+        }
+
+        return inviteeRecord;
       };
 
       const buildInviteesRequestUrl = baseUrl => {

--- a/scripts/message-utils.js
+++ b/scripts/message-utils.js
@@ -315,6 +315,18 @@
     let firstNamePart = nameParts.firstName;
     let lastNamePart = nameParts.lastName;
 
+    const explicitFirstName =
+      invitee && typeof invitee.nombre === 'string' ? invitee.nombre.trim() : '';
+    const explicitLastName =
+      invitee && typeof invitee.apellidos === 'string' ? invitee.apellidos.trim() : '';
+
+    if (explicitFirstName) {
+      firstNamePart = explicitFirstName;
+    }
+    if (explicitLastName) {
+      lastNamePart = explicitLastName;
+    }
+
     if (!firstNamePart) {
       if (rawDisplayName) {
         firstNamePart = rawDisplayName;
@@ -408,7 +420,7 @@
       .map(paragraph => replacePlaceholders(paragraph, replacements))
       .filter(Boolean);
 
-    const heading = name === 'Invitad@' ? 'Invitación especial' : `Invitación para ${name}`;
+    const heading = name === 'Invitad@' ? 'Invitación especial' : 'Invitación para:';
 
     const whatsappTemplate =
       typeof options.whatsappTemplate === 'string' && options.whatsappTemplate.trim()


### PR DESCRIPTION
## Summary
- keep the public invitation heading static while updating metadata titles with the guest name
- read separate first and last name columns from the CSV for use across the invite messaging
- update the admin preview so it continues to show the guest name alongside the heading

## Testing
- _No automated tests were run (not requested)_

------
https://chatgpt.com/codex/tasks/task_e_68dcb04208dc8325ba8a543e916e320f