### PR TITLE
Remove script fonts from admin guest page

### DIFF
--- a/admin-invitados.html
+++ b/admin-invitados.html
@@ -6,7 +6,7 @@
   <title>Admin de invitados – Slugs & WhatsApp</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Playfair+Display:wght@400;500;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;600&display=swap" rel="stylesheet">
   <style>
     :root {
       color-scheme: light;
@@ -513,10 +513,11 @@
     }
 
     .guest-name-first {
-      font-family: 'Great Vibes', 'Segoe Script', cursive;
-      font-size: 1.4rem;
-      line-height: 1.1;
-      letter-spacing: 0.02em;
+      font-family: 'Playfair Display', 'Cormorant Garamond', 'Montserrat', serif;
+      font-size: 1.35rem;
+      line-height: 1.2;
+      letter-spacing: 0.03em;
+      font-weight: 600;
       color: #0f172a;
       text-align: center;
     }


### PR DESCRIPTION
## Summary
- remove the Great Vibes script font from the admin invitados page
- update the guest name styling to rely on Playfair Display for improved readability

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dcb8cee828832599b29c7ddbaec208