### PR TITLE
Ensure envelope intro displays for reduced motion users

### DIFF
--- a/scripts/envelope-intro.js
+++ b/scripts/envelope-intro.js
@@ -127,10 +127,12 @@
       openButton.disabled = true;
       skipButton.disabled = true;
 
+      const animationDuration = reduceMotionQuery.matches ? 0 : 1700;
+
       animationTimeoutId = window.setTimeout(() => {
         skipButton.disabled = false;
         finishIntro();
-      }, 1700);
+      }, animationDuration);
     };
 
     const skipIntro = () => {
@@ -153,9 +155,7 @@
 
       window.requestAnimationFrame(() => {
         window.setTimeout(() => {
-          if (!reduceMotionQuery.matches) {
-            openButton.focus();
-          }
+          openButton.focus();
         }, 120);
       });
 
@@ -169,7 +169,7 @@
       }, 6000);
     };
 
-    const shouldSkipIntro = () => reduceMotionQuery.matches || safeSessionGet() === '1';
+    const shouldSkipIntro = () => safeSessionGet() === '1';
 
     main.setAttribute('aria-hidden', 'false');
     intro.setAttribute('aria-hidden', 'true');
@@ -179,9 +179,7 @@
       intro.setAttribute('aria-hidden', 'true');
       intro.style.display = 'none';
       unlockScroll();
-      if (!reduceMotionQuery.matches) {
-        safeSessionSet('1');
-      }
+      safeSessionSet('1');
       return;
     }
 


### PR DESCRIPTION
## Summary
- allow the invitation envelope intro to show even when the user prefers reduced motion
- make the opening sequence finish immediately without animation when motion is reduced and keep the open button focusable

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd53901ac08325b0e1e1ea6d90a266