### PR TITLE
Adjust envelope intro animation timing and size

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -72,8 +72,8 @@ body.intro-active #envelope-intro {
 
 #envelope-intro .envelope-stage {
   position: relative;
-  width: min(82vw, 440px);
-  aspect-ratio: 4 / 3;
+  width: 90vw;
+  height: 90vh;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -86,7 +86,7 @@ body.intro-active #envelope-intro {
   border-radius: 26px;
   perspective: 1400px;
   filter: drop-shadow(0 28px 60px rgba(47, 79, 79, 0.22));
-  animation: envelopeIntroFade 0.35s ease-out forwards;
+  animation: envelopeIntroFade 2s ease-out forwards;
 }
 
 @keyframes envelopeIntroFade {


### PR DESCRIPTION
## Summary
- expand the intro envelope stage to occupy 90% of the viewport height and width
- slow the opening animation fade-in to a fixed 2 second duration for better visibility

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd591aad448325972270bad8c76846