### PR TITLE
Add sticky storytelling scroll panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Playfair+Display:wght@400;500;600;700&family=Lato:wght@300;400;500;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script src="https://cdn.tailwindcss.com?plugins=typography" defer></script>
+  <script src="scripts/sticky-flow.js" defer></script>
   <script>
     tailwind = window.tailwind || {};
     tailwind.config = {
@@ -151,6 +152,107 @@
         </div>
       </div>
     </header>
+
+    <section
+      class="sticky-story"
+      aria-label="Momentos que nos trajeron hasta aquí"
+    >
+      <div class="sticky-flow" data-sticky-flow>
+        <div class="panel-wrapper" data-panel-wrapper>
+          <section class="panel panel--intro" aria-labelledby="panel-intro-title">
+            <div class="panel__content">
+              <p class="panel__eyebrow">Desde el primer encuentro</p>
+              <h2 id="panel-intro-title" class="panel__title">Cuando dos caminos se cruzaron</h2>
+              <p class="panel__description">
+                Una tarde cualquiera de 2018 se volvió inolvidable. Entre conversaciones sin prisa y una risa compartida,
+                supimos que habíamos encontrado un hogar en la mirada del otro. Desde entonces, cada aventura ha estado llena
+                de pequeños detalles, playlists interminables y viajes improvisados.
+              </p>
+              <figure class="panel__media">
+                <img
+                  src="images/Foto (2).jpg"
+                  alt="Carmen y Alfredo caminando juntos en un atardecer"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </figure>
+            </div>
+          </section>
+        </div>
+
+        <div class="panel-wrapper" data-panel-wrapper>
+          <section class="panel panel--journey" aria-labelledby="panel-journey-title">
+            <div class="panel__content">
+              <p class="panel__eyebrow">Los capítulos que escribimos</p>
+              <h2 id="panel-journey-title" class="panel__title">Una historia contada paso a paso</h2>
+              <p class="panel__description">
+                Nuestro amor creció entre ciudades, conciertos, reuniones familiares y tardes de cocina experimental. Cada
+                celebración, cada abrazo y cada noche de películas ha tejido una red de memorias que hoy queremos compartir
+                con ustedes.
+              </p>
+              <ul class="panel__list">
+                <li>2019 — Un sí a la aventura: nuestro primer viaje juntos.</li>
+                <li>2021 — Nuevos comienzos al mudarnos al mismo hogar.</li>
+                <li>2023 — Un brindis por los sueños que seguimos persiguiendo de la mano.</li>
+              </ul>
+              <figure class="panel__media">
+                <img
+                  src="images/Foto (4).jpg"
+                  alt="Carmen y Alfredo celebrando con amigos"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </figure>
+            </div>
+          </section>
+        </div>
+
+        <div class="panel-wrapper" data-panel-wrapper>
+          <section class="panel panel--proposal" aria-labelledby="panel-proposal-title">
+            <div class="panel__content">
+              <p class="panel__eyebrow">La promesa</p>
+              <h2 id="panel-proposal-title" class="panel__title">Un anillo, un sí y un mar de emociones</h2>
+              <p class="panel__description">
+                En 2024, frente a un cielo lleno de estrellas, Alfredo preguntó y Carmen respondió con un sí emocionado. Fue un
+                instante íntimo, sincero y profundamente nuestro, el preludio perfecto para esta celebración que está por
+                llegar.
+              </p>
+              <figure class="panel__media">
+                <img
+                  src="images/Foto (6).jpg"
+                  alt="Detalle de la propuesta de matrimonio"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </figure>
+            </div>
+          </section>
+        </div>
+
+        <div class="panel-wrapper" data-panel-wrapper>
+          <section class="panel panel--celebration" aria-labelledby="panel-celebration-title">
+            <div class="panel__content">
+              <p class="panel__eyebrow">Lo que viene</p>
+              <h2 id="panel-celebration-title" class="panel__title">El 8 de noviembre nos reunimos para celebrar</h2>
+              <p class="panel__description">
+                Queremos que cada invitado se sienta parte de nuestra historia. Prepárense para una tarde llena de abrazos,
+                música romántica y momentos que recordaremos siempre. Gracias por acompañarnos en este viaje que apenas
+                comienza.
+              </p>
+              <a class="panel__cta" href="#itinerario">Descubre el itinerario completo</a>
+              <figure class="panel__media">
+                <img
+                  src="images/Foto (8).jpg"
+                  alt="Brindis al atardecer en Villa La Perla"
+                  loading="lazy"
+                  decoding="async"
+                />
+              </figure>
+            </div>
+          </section>
+        </div>
+      </div>
+    </section>
 
     <main id="invite" class="max-w-4xl mx-auto px-5 sm:px-6 lg:px-8 space-y-16 py-12 sm:py-16">
       <section id="contador">

--- a/scripts/sticky-flow.js
+++ b/scripts/sticky-flow.js
@@ -1,0 +1,143 @@
+(function () {
+  const CONFIG = {
+    STICKY_DURATION_VH: 150,
+    FADE_DISTANCE_REM: 2,
+    TRANSITION_MS: 520,
+    EASING: 'cubic-bezier(0.22, 1, 0.36, 1)',
+    USE_ZINDEX_STACKING: true
+  };
+
+  const setDesignTokens = () => {
+    const root = document.documentElement;
+    root.style.setProperty('--sticky-duration', `${CONFIG.STICKY_DURATION_VH}vh`);
+    root.style.setProperty('--sticky-fade-distance', `${CONFIG.FADE_DISTANCE_REM}rem`);
+    root.style.setProperty('--sticky-transition', `${CONFIG.TRANSITION_MS}ms`);
+    root.style.setProperty('--sticky-easing', CONFIG.EASING);
+  };
+
+  const throttleFrame = (callback) => {
+    let ticking = false;
+    return (...args) => {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(() => {
+        callback.apply(null, args);
+        ticking = false;
+      });
+    };
+  };
+
+  const initialiseStickyFlow = () => {
+    const flow = document.querySelector('[data-sticky-flow]');
+    if (!flow) return;
+
+    const wrappers = Array.from(flow.querySelectorAll('[data-panel-wrapper]'));
+    if (!wrappers.length) return;
+
+    const useZIndexStacking = CONFIG.USE_ZINDEX_STACKING || flow.hasAttribute('data-use-zindex');
+
+    wrappers.forEach((wrapper, index) => {
+      const panel = wrapper.querySelector('.panel');
+      if (!panel) return;
+      panel.dataset.panelIndex = String(index);
+      if (useZIndexStacking) {
+        panel.style.zIndex = String(100 + index);
+      }
+    });
+
+    let activeIndex = -1;
+
+    const setActive = (nextIndex) => {
+      const index = Math.max(0, Math.min(wrappers.length - 1, nextIndex));
+      if (index === activeIndex) return;
+      activeIndex = index;
+
+      wrappers.forEach((wrapper, position) => {
+        const panel = wrapper.querySelector('.panel');
+        if (!panel) return;
+        const isActive = position === index;
+        panel.classList.toggle('is-active', isActive);
+        panel.classList.toggle('is-prev', position < index);
+        panel.classList.toggle('is-next', position === index + 1);
+      });
+    };
+
+    const updateByViewport = () => {
+      let candidateIndex = 0;
+      let candidateScore = Number.POSITIVE_INFINITY;
+      const viewportMiddle = window.innerHeight / 2;
+
+      wrappers.forEach((wrapper, index) => {
+        const rect = wrapper.getBoundingClientRect();
+        const wrapperMiddle = rect.top + Math.min(rect.height, window.innerHeight) / 2;
+        const distance = Math.abs(wrapperMiddle - viewportMiddle);
+        if (distance < candidateScore) {
+          candidateScore = distance;
+          candidateIndex = index;
+        }
+      });
+
+      setActive(candidateIndex);
+    };
+
+    const onScrollFallback = throttleFrame(updateByViewport);
+
+    const thresholds = Array.from({ length: 21 }, (_, i) => i / 20);
+    const observerOptions = {
+      root: null,
+      threshold: thresholds,
+      rootMargin: '-20% 0px -20% 0px'
+    };
+
+    const handleIntersections = (entries) => {
+      entries
+        .filter((entry) => entry.isIntersecting)
+        .sort((a, b) => b.intersectionRatio - a.intersectionRatio)
+        .forEach((entry) => {
+          const wrapper = entry.target;
+          const index = wrappers.indexOf(wrapper);
+          if (index === -1) return;
+          if (entry.intersectionRatio >= 0.55) {
+            setActive(index);
+          }
+        });
+    };
+
+    if ('IntersectionObserver' in window) {
+      const observer = new IntersectionObserver(handleIntersections, observerOptions);
+      wrappers.forEach((wrapper) => observer.observe(wrapper));
+      setActive(0);
+    } else {
+      window.addEventListener('scroll', onScrollFallback, { passive: true });
+      window.addEventListener('resize', onScrollFallback);
+      updateByViewport();
+    }
+
+    const motionMedia = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const applyMotionPreference = () => {
+      if (motionMedia.matches) {
+        setActive(activeIndex === -1 ? 0 : activeIndex);
+        return;
+      }
+
+      if ('IntersectionObserver' in window) {
+        setActive(activeIndex === -1 ? 0 : activeIndex);
+      } else {
+        updateByViewport();
+      }
+    };
+
+    motionMedia.addEventListener('change', applyMotionPreference);
+    applyMotionPreference();
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+      setDesignTokens();
+      initialiseStickyFlow();
+    });
+  } else {
+    setDesignTokens();
+    initialiseStickyFlow();
+  }
+})();

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,10 @@
   --forest: #2F4F4F;
   --sage: #8DA08C;
   --gold: #C2A675;
+  --sticky-duration: 150vh;
+  --sticky-fade-distance: 2rem;
+  --sticky-transition: 480ms;
+  --sticky-easing: cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 body {
@@ -659,4 +663,235 @@ body {
 
 .bank-card__feedback.is-visible {
   opacity: 1;
+}
+
+.sticky-story {
+  position: relative;
+  padding: clamp(4rem, 10vh, 6rem) 0 clamp(5rem, 12vh, 7rem);
+  isolation: isolate;
+}
+
+.sticky-flow {
+  position: relative;
+  width: min(1200px, 92vw);
+  margin: 0 auto;
+}
+
+.panel-wrapper {
+  position: relative;
+  min-height: var(--sticky-duration, 150vh);
+}
+
+.panel {
+  position: sticky;
+  top: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(3rem, 6vw, 5rem) clamp(1.5rem, 5vw, 4rem);
+  border-radius: clamp(2rem, 4vw, 3.5rem);
+  background: var(--panel-bg, rgba(250, 247, 242, 0.95));
+  color: var(--panel-fg, var(--forest));
+  box-shadow: 0 -42px 90px -64px rgba(47, 79, 79, 0.32), 0 60px 120px -70px rgba(47, 79, 79, 0.4);
+  overflow: clip;
+  opacity: 0;
+  transform: translate3d(0, var(--sticky-fade-distance, 2rem), 0);
+  transition: opacity var(--sticky-transition, 480ms) var(--sticky-easing, cubic-bezier(0.22, 1, 0.36, 1)),
+    transform var(--sticky-transition, 480ms) var(--sticky-easing, cubic-bezier(0.22, 1, 0.36, 1));
+  will-change: transform, opacity;
+  contain: layout paint style;
+  content-visibility: auto;
+}
+
+.panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(to bottom, rgba(47, 79, 79, 0.14), transparent 30%);
+  opacity: 0;
+  transition: opacity var(--sticky-transition, 480ms) var(--sticky-easing, cubic-bezier(0.22, 1, 0.36, 1));
+}
+
+.panel.is-active {
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+}
+
+.panel.is-active::before {
+  opacity: 0.35;
+}
+
+.panel.is-prev {
+  opacity: 0;
+  transform: translate3d(0, calc(var(--sticky-fade-distance, 2rem) * -0.6), 0);
+}
+
+.panel.is-next {
+  opacity: 0.35;
+}
+
+.panel__content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(1.25rem, 3vw, 2.75rem);
+  max-width: min(760px, 92vw);
+  margin: 0 auto;
+  padding: clamp(1.25rem, 3vw, 3rem);
+  text-align: center;
+  z-index: 1;
+}
+
+.panel__eyebrow {
+  font-size: 0.85rem;
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  color: rgba(47, 79, 79, 0.6);
+}
+
+.panel__title {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2.4rem, 4vw, 3.4rem);
+  line-height: 1.1;
+  text-wrap: balance;
+}
+
+.panel__description,
+.panel__list,
+.panel__cta {
+  font-size: clamp(1.05rem, 2.2vw, 1.35rem);
+  line-height: 1.65;
+  color: rgba(47, 79, 79, 0.85);
+}
+
+.panel__list {
+  display: grid;
+  gap: 0.75rem;
+  padding-left: 0;
+  list-style: none;
+}
+
+.panel__list li {
+  position: relative;
+  padding-left: 1.5rem;
+  text-align: left;
+}
+
+.panel__list li::before {
+  content: '✦';
+  position: absolute;
+  left: 0;
+  color: rgba(194, 166, 117, 0.9);
+  font-size: 0.85em;
+  top: 0.25em;
+}
+
+.panel__media {
+  width: min(420px, 85vw);
+  border-radius: clamp(1.5rem, 3vw, 2.5rem);
+  overflow: hidden;
+  box-shadow: 0 38px 95px -38px rgba(47, 79, 79, 0.55);
+}
+
+.panel__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transform: scale(1.02);
+  transition: transform var(--sticky-transition, 480ms) var(--sticky-easing, cubic-bezier(0.22, 1, 0.36, 1));
+}
+
+.panel.is-active .panel__media img {
+  transform: scale(1);
+}
+
+.panel__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  align-self: center;
+  padding: 0.85rem 1.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(194, 166, 117, 0.55);
+  background: rgba(250, 247, 242, 0.8);
+  color: rgba(47, 79, 79, 0.85);
+  text-decoration: none;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  transition: border-color 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
+}
+
+.panel__cta:hover,
+.panel__cta:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(194, 166, 117, 0.85);
+  background: rgba(231, 216, 201, 0.8);
+}
+
+.panel__cta:focus-visible {
+  outline: 3px solid rgba(194, 166, 117, 0.45);
+  outline-offset: 4px;
+}
+
+.panel--intro {
+  --panel-bg: rgba(250, 247, 242, 0.95);
+}
+
+.panel--journey {
+  --panel-bg: rgba(231, 216, 201, 0.92);
+}
+
+.panel--proposal {
+  --panel-bg: rgba(213, 206, 197, 0.92);
+}
+
+.panel--celebration {
+  --panel-bg: rgba(250, 247, 242, 0.96);
+}
+
+@media (min-width: 768px) {
+  .panel__content {
+    text-align: left;
+    align-items: flex-start;
+  }
+
+  .panel__eyebrow {
+    letter-spacing: 0.5em;
+  }
+
+  .panel__media {
+    align-self: flex-end;
+  }
+}
+
+@supports (height: 100svh) {
+  .panel {
+    min-height: 100svh;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .panel,
+  .panel::before,
+  .panel__media img,
+  .panel__cta {
+    transition-duration: 0.01ms !important;
+    transition-delay: 0s !important;
+  }
+
+  .panel,
+  .panel.is-prev,
+  .panel.is-next {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+
+  .panel::before {
+    opacity: 0 !important;
+  }
 }


### PR DESCRIPTION
## Summary
- add a four-panel sticky storytelling flow between the hero and invitation content
- style the new sticky panels with smooth transitions, stacking, and reduced-motion support
- implement lightweight IntersectionObserver logic to drive panel activation with a scroll fallback

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68dd7c8daa74832593dd4a8c7a7300ac