### PR TITLE
Add sticky scroll transitions for main sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
     }
   </style>
   <link rel="stylesheet" href="styles.css" />
+  <script src="scripts/sticky-flow.js" defer></script>
   <meta property="og:type" content="event" />
   <meta property="og:title" content="Boda de Carmen & Alfredo — 8 de noviembre de 2025" />
   <meta property="og:description" content="Celebremos juntos en Villa La Perla, Calvillo. Consulta el itinerario, la ubicación y comparte tus recuerdos." />

--- a/scripts/sticky-flow.js
+++ b/scripts/sticky-flow.js
@@ -1,0 +1,139 @@
+(function () {
+  const supportsStickyPosition = () => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      return false;
+    }
+    const testElement = document.createElement('div');
+    const values = ['sticky', '-webkit-sticky'];
+    return values.some(value => {
+      testElement.style.position = value;
+      return testElement.style.position === value;
+    });
+  };
+
+  const throttle = (fn, wait = 60) => {
+    let timeoutId = null;
+    let lastCall = 0;
+    return function throttledFn(...args) {
+      const now = Date.now();
+      const remaining = wait - (now - lastCall);
+      const invoke = () => {
+        lastCall = Date.now();
+        timeoutId = null;
+        fn.apply(this, args);
+      };
+      if (remaining <= 0 || remaining > wait) {
+        if (timeoutId) {
+          window.clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+        lastCall = now;
+        fn.apply(this, args);
+      } else if (!timeoutId) {
+        timeoutId = window.setTimeout(invoke, remaining);
+      }
+    };
+  };
+
+  const initializeStickyFlow = () => {
+    const container =
+      document.querySelector('#sticky-flow') ||
+      document.querySelector('[data-sticky-flow]') ||
+      document.querySelector('main');
+
+    if (!container) return;
+
+    const sections = Array.from(container.children).filter(child => child.tagName && child.tagName.toLowerCase() === 'section');
+    if (!sections.length) return;
+
+    container.classList.add('sticky-flow');
+
+    sections.forEach(section => {
+      section.classList.add('panel');
+    });
+
+    const hasStickySupport = supportsStickyPosition();
+    if (!hasStickySupport) {
+      container.classList.add('sticky-flow--no-sticky');
+    }
+
+    let activeIndex = -1;
+    let rafId = null;
+    let initialized = false;
+
+    const applyStates = index => {
+      if (index < 0 || index >= sections.length) return;
+      activeIndex = index;
+      sections.forEach((panel, panelIndex) => {
+        panel.classList.toggle('is-active', panelIndex === index);
+        panel.classList.toggle('is-prev', panelIndex === index - 1);
+        panel.classList.toggle('is-next', panelIndex === index + 1);
+      });
+    };
+
+    const updateStates = () => {
+      rafId = null;
+      const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+      let bestIndex = 0;
+      let bestVisible = -1;
+
+      sections.forEach((panel, index) => {
+        const rect = panel.getBoundingClientRect();
+        const top = Math.max(rect.top, 0);
+        const bottom = Math.min(rect.bottom, viewportHeight);
+        const visible = bottom - top;
+        const clamped = visible > 0 ? visible : 0;
+        if (clamped > bestVisible) {
+          bestVisible = clamped;
+          bestIndex = index;
+        }
+      });
+
+      applyStates(bestIndex);
+
+      if (!initialized) {
+        container.classList.add('sticky-flow--initialized');
+        initialized = true;
+      }
+    };
+
+    const requestStateUpdate = () => {
+      if (rafId != null) return;
+      rafId = window.requestAnimationFrame(updateStates);
+    };
+
+    const throttledRequestUpdate = throttle(requestStateUpdate, 60);
+
+    if ('IntersectionObserver' in window) {
+      const observer = new IntersectionObserver(() => {
+        requestStateUpdate();
+      }, {
+        root: null,
+        rootMargin: '-40% 0px -40% 0px',
+        threshold: [0, 0.25, 0.5, 0.75, 1]
+      });
+      sections.forEach(panel => observer.observe(panel));
+      requestStateUpdate();
+    } else {
+      const handleScroll = () => throttledRequestUpdate();
+      window.addEventListener('scroll', handleScroll, { passive: true });
+      window.addEventListener('resize', throttledRequestUpdate);
+      window.addEventListener('orientationchange', throttledRequestUpdate);
+      throttledRequestUpdate();
+    }
+
+    if ('IntersectionObserver' in window) {
+      window.addEventListener('resize', throttledRequestUpdate);
+      window.addEventListener('orientationchange', throttledRequestUpdate);
+    }
+
+    applyStates(0);
+    requestStateUpdate();
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeStickyFlow, { once: true });
+  } else {
+    initializeStickyFlow();
+  }
+})();

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,9 @@
   --forest: #2F4F4F;
   --sage: #8DA08C;
   --gold: #C2A675;
+  --panel-duration: clamp(20vh, 30vh, 40vh);
+  --t: 480ms;
+  --ease: cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 body {
@@ -668,4 +671,61 @@ body {
 
 .bank-card__feedback.is-visible {
   opacity: 1;
+}
+
+.sticky-flow {
+  position: relative;
+}
+
+.sticky-flow > .panel {
+  position: sticky;
+  top: 0;
+  min-height: 100vh;
+  margin-bottom: var(--panel-duration);
+  overflow: clip;
+  opacity: 0;
+  transform: translateY(2rem);
+  transition: opacity var(--t) var(--ease), transform var(--t) var(--ease);
+  z-index: 0;
+  will-change: opacity, transform;
+  content-visibility: auto;
+  contain-intrinsic-size: 100vh;
+}
+
+.sticky-flow > .panel + .panel {
+  margin-top: 0;
+}
+
+.sticky-flow:not(.sticky-flow--initialized) > .panel {
+  opacity: 1;
+  transform: none;
+}
+
+.sticky-flow > .panel.is-active {
+  opacity: 1;
+  transform: none;
+  z-index: 2;
+  content-visibility: visible;
+}
+
+.sticky-flow > .panel.is-next {
+  z-index: 1;
+}
+
+.sticky-flow--no-sticky > .panel {
+  position: static;
+  opacity: 1;
+  transform: none;
+}
+
+.sticky-flow--no-sticky > .panel:not(.is-active) {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sticky-flow > .panel {
+    transition: none;
+    opacity: 1;
+    transform: none;
+  }
 }


### PR DESCRIPTION
## Summary
- add a deferred sticky-flow script that decorates main sections and drives active/prev/next states with IntersectionObserver plus scroll fallback
- extend the stylesheet with configurable variables and panel animation rules for the sticky scroll experience
- include the new script on the homepage so the effect runs without altering section markup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd812a33b08325b6355e22d06bfd67