### PR TITLE
Fix bank card alignment

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -485,6 +485,8 @@ body {
 .bank-card {
   display: flex;
   justify-content: center;
+  width: min(100%, 26rem);
+  margin-inline: auto;
   perspective: 1600px;
   cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- constrain the bank card container width and center it so the flip animation no longer shifts the card to the side

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68deb0a7d73483258c70f2151c1a5de0