### PR TITLE
Ensure bank card content is centered

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -502,6 +502,8 @@ body {
   grid-template-columns: 1fr;
   width: 100%;
   max-width: 26rem;
+  place-items: center;
+  text-align: center;
   transform-style: preserve-3d;
   transition: transform 0.7s cubic-bezier(0.2, 0.85, 0.4, 1);
 }
@@ -584,12 +586,14 @@ body {
   font-size: 1.25rem;
   font-weight: 600;
   color: rgba(47, 79, 79, 0.92);
+  text-align: center;
 }
 
 .bank-card__subtitle {
   font-size: 0.95rem;
   color: rgba(47, 79, 79, 0.65);
   line-height: 1.55;
+  text-align: center;
 }
 
 .bank-card__actions {
@@ -619,6 +623,7 @@ body {
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  text-align: center;
   transition: background-color 0.25s ease, border-color 0.25s ease,
     box-shadow 0.25s ease, transform 0.2s ease;
 }


### PR DESCRIPTION
## Summary
- center the bank card inner grid content so both faces align centrally

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68deb6e8d5d48325aa76d1aaf58ed031