### PR TITLE
Add guest URL to reminder reminder template

### DIFF
--- a/scripts/message-utils.js
+++ b/scripts/message-utils.js
@@ -24,6 +24,8 @@
     'Tu presencia sería muy especial para nosotros.',
     'Cuando tengas un momento, ¿podrías confirmarnos por favor?',
     '',
+    '{url}',
+    '',
     'Con mucho cariño,',
     '',
     'Carmen y Alfredo'
@@ -454,7 +456,8 @@
     const reminderTemplate = DEFAULT_REMINDER_TEMPLATE;
     const reminderMessage = collapseBlankLines(
       replacePlaceholders(reminderTemplate, {
-        name: reminderName
+        name: reminderName,
+        url
       })
     );
     const encodedReminderWhatsappMessage = reminderMessage ? encodeURIComponent(reminderMessage) : '';


### PR DESCRIPTION
## Summary
- include the guest-specific URL line in the default reminder WhatsApp template
- pass the invite link into the reminder message replacements so it is rendered per guest

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69027f811f3483259523ab921857c054